### PR TITLE
Fix function GotoCurrentZone

### DIFF
--- a/Carbonite/NxMap.lua
+++ b/Carbonite/NxMap.lua
@@ -9552,7 +9552,7 @@ function Nx.Map:GotoCurrentZone()
 		self:Move (self.PlyrX, self.PlyrY, 20, 15)
 	else
 		self:SetToCurrentZone()
-		local mapId = self:GetCurrentMapId()
+		local mapId = MapUtil.GetDisplayableMapForPlayer()
 		self:CenterMap (mapId)
 	end
 end


### PR DESCRIPTION
issue: in Options -> Maps -> Map Mouse Button Binds; the option to "Show Player Zone" should move/zoom map to player's current zone, instead it moves/zooms to the zone you clicked on

to reproduce: with fresh addon install, middle-click any map and see that it zooms into wrong map

my view of the problem: 'GetCurrentMapId()' is returning id of mouse-over map zone, not current player zone

my solution: replace 'GetCurrentMapId()' with 'MapUtil.GetDisplayableMapForPlayer()'