### PR TITLE
Implemented TomTom Callbacks into the NxMap source file.

### DIFF
--- a/Carbonite/Carbonite.lua
+++ b/Carbonite/Carbonite.lua
@@ -160,6 +160,8 @@ function Nx.EmulateTomTom()
 	tom["AddMFWaypoint"] = Nx.TTSetCustomMFWaypoint
 	tom["RemoveWaypoint"] = Nx.TTRemoveWaypoint
 	tom["SetCrazyArrow"] = Nx.TTSetCrazyArrow
+	tom["DefaultCallbacks"] = Nx.TTDefaultCallbacks
+	tom["SetClosestWaypoint"] = Nx.TTSetClosestWaypoint
 	SLASH_WAY1 = '/way'
 	SLASH_CBWAY1 = '/cbway'
 	SlashCmdList["WAY"] = function (msg, editbox)


### PR DESCRIPTION
![image](https://github.com/IrcDirk/Carbonite-Classic/assets/15069481/66ef2a63-42f9-45b7-aa86-b07a93905a3a)

This pull request adds support for TomTom's DefaultCallbacks function and its associated behaviors. If a waypoint is added with a callback specified, the callbacks will take priority over the tooltip display generated by the icon associated with the target.

Additionally, this pull request also extends Carbonite to add an AddTarget method, which will allow other addons to add their own targets utilizing Carbonite's expected data format. The existing SetTarget function will now inherently use the AddTarget method in order to preserve the behavior of the addon as it was previously.


**Unrelated to the Pull Request Itself**

Something of note that I recognized while doing this adjustment is that Carbonite utilizes a lot of global variables and if performance is something to be desired, it might be a good idea to locally cache globals referenced by functions that get called a lot. (such as ceil, tostring, format, pairs, ipairs) Even the Nx variable itself is a global, which might be negatively affecting the performance capabilities of the addon.