### PR TITLE
Restores Delve scenario tracking in the quest watch frame and fixes intermittent duplicate objective progress counts caused by party synchronization.

### DIFF
--- a/Carbonite.Quests/BlizzardLog.lua
+++ b/Carbonite.Quests/BlizzardLog.lua
@@ -16,7 +16,6 @@ local bit_band   = bit.band
 local bit_lshift = bit.lshift
 local strfind    = strfind  or string.find
 local strsub     = strsub   or string.sub
-local strmatch   = strmatch or string.match
 local format     = format   or string.format
 local gsub       = gsub     or string.gsub
 local tinsert    = tinsert  or table.insert
@@ -1118,31 +1117,33 @@ function Nx.Quest:QuestQueryTimer()
     end
 end
 
-function Nx.Quest:CalcDesc (qId, objI, cnt, total)
+function Nx.Quest:CalcDesc (qId, objI, cnt, total, fallbackDesc)
 
-    local odesc = Nx.Quest:GetQuestObjectiveInfo(qId, objI, false);
-    local desc, _, _ = strmatch (odesc or "", "(.+): (%d+)/(%d+)")
-
-    if not desc then
-        desc = odesc or "?"
-    end
+    local odesc, _, objectiveDone, liveCnt, liveTotal = Nx.Quest:GetQuestObjectiveInfo (qId, objI, false)
+    cnt = tonumber (liveCnt) or tonumber (cnt) or 0
+    total = tonumber (liveTotal) or tonumber (total) or 0
+    local desc = self:NormalizeObjectiveProgressText (odesc or fallbackDesc, cnt, total)
 
 --    Nx.prt("%s, %s, %s, %s, %s", qId, objI, desc, cnt, total)
 
     if total == 0 then
-        return desc, cnt == 1
+        return desc, objectiveDone or cnt == 1
     else
-        return format ("%s: %d/%d", desc, cnt, total), cnt >= total
+        return desc, objectiveDone or cnt >= total
     end
 end
 
 function Nx.Quest:GetQuestObjectiveInfo(qId, objI, qText)
+    if not C_QuestLog or not C_QuestLog.GetQuestObjectives then
+        return
+    end
+
     local obj = C_QuestLog.GetQuestObjectives(qId)
 
     obj = (obj and obj[objI]) or nil
 
     if obj then
-        return obj.text, obj.type, obj.finished
+        return obj.text, obj.type, obj.finished, obj.numFulfilled, obj.numRequired
     end
 
     return

--- a/Carbonite.Quests/CHANGELOG.md
+++ b/Carbonite.Quests/CHANGELOG.md
@@ -1,0 +1,24 @@
+# Carbonite Quests Project Changelog
+
+## 2026-08-10 — Intermittent duplicate objective progress
+
+- Fixed quest objectives alternating between a single progress count and a
+  duplicated count, such as `1/1 1/1 Obtain the arcane projector from Rommath`.
+- Stopped the party-share serializer from rewriting the live objective text
+  used by the watch window.
+- Normalized count-first and count-last objective strings at the party
+  communication boundary so each objective contains exactly one progress
+  value.
+- Preferred Blizzard's structured `numFulfilled` and `numRequired` fields,
+  with legacy text parsing retained as a fallback.
+- Added feature guards for clients without `C_QuestLog.GetQuestObjectives`.
+
+### Validation
+
+- Lua 5.1 parsing passed for all affected quest files.
+- Count-first, count-last, duplicated, parenthesized, and bracketed progress
+  formats passed normalization tests.
+- Party serialization retained the original live objective text in a runtime
+  test.
+- The prior Retail Delve scenario renderer and its Classic fallback passed
+  regression tests.

--- a/Carbonite.Quests/DataAndComm.lua
+++ b/Carbonite.Quests/DataAndComm.lua
@@ -1042,6 +1042,57 @@ local pmsg_elapsed = 0
 local pmsg_lasttime
 local pmsg_ttl = 9999
 
+-------------------------------------------------------------------------------
+-- Return one canonical objective-progress string for party synchronization.
+--
+-- Modern clients can put the numeric progress at the start of objective.text,
+-- while older clients commonly put it at the end. Carbonite's party protocol
+-- also carries the numeric values separately. Strip matching edge tokens before
+-- appending the protocol values so repeated send/receive passes cannot turn
+-- "1/1 Objective" into "1/1 Objective: 1/1".
+-------------------------------------------------------------------------------
+
+function Nx.Quest:NormalizeObjectiveProgressText (text, count, required)
+    if type (text) ~= "string" then
+        text = "?"
+    end
+
+    count = tonumber (count)
+    required = tonumber (required)
+
+    text = string.match (text, "^%s*(.-)%s*$") or text
+
+    if not count or not required or required <= 0 then
+        return text ~= "" and text or "?"
+    end
+
+    local token = tostring (count) .. "%s*/%s*" .. tostring (required)
+    local previous
+
+    repeat
+        previous = text
+
+        -- Count-first forms: "1/1 Objective", "(1/1) Objective", etc.
+        text = string.gsub (text, "^%s*" .. token .. "%s*:?%s*", "", 1)
+        text = string.gsub (text, "^%s*%(" .. token .. "%)%s*:?%s*", "", 1)
+        text = string.gsub (text, "^%s*%[" .. token .. "%]%s*:?%s*", "", 1)
+
+        -- Count-last forms: "Objective: 1/1", "Objective (1/1)", etc.
+        text = string.gsub (text, "%s*:%s*" .. token .. "%s*$", "", 1)
+        text = string.gsub (text, "%s*%(" .. token .. "%)%s*$", "", 1)
+        text = string.gsub (text, "%s*%[" .. token .. "%]%s*$", "", 1)
+        text = string.gsub (text, "%s+" .. token .. "%s*$", "", 1)
+
+        text = string.match (text, "^%s*(.-)%s*$") or text
+    until text == previous
+
+    if text == "" then
+        text = "?"
+    end
+
+    return format ("%s: %d/%d", text, count, required)
+end
+
 function Nx.Quest:OnPartyMsg (plName, msg)
 
     if Nx.qdb and Nx.qdb.profile and not Nx.qdb.profile.Quest.PartyShare then
@@ -1101,6 +1152,8 @@ function Nx.Quest:OnPartyMsg (plName, msg)
                     local o = off + 6 + (i - 1) * 4
                     local cnt = tonumber (strsub (msg, o, o + 1), 16) or 0
                     local total = tonumber (strsub (msg, o + 2, o + 3), 16) or 0
+
+                    desc = self:NormalizeObjectiveProgressText (desc, cnt, total)
 
                     q[i] = cnt
                     q[i + 100] = total
@@ -1183,12 +1236,12 @@ function Nx.Quest:PartyBuildSendData()
 
             for n = 1, cur.LBCnt do
 
-                local _, _, cnt, total = strfind (cur[n], "(%d+)/(%d+)")
-                cnt = tonumber (cnt or 0)
-                total = tonumber (total or 0)
+                local _, _, parsedCnt, parsedTotal = strfind (cur[n] or "", "(%d+)%s*/%s*(%d+)")
+                local _, _, _, liveCnt, liveTotal = self:GetQuestObjectiveInfo (qId, n, false)
+                local cnt = tonumber (liveCnt) or tonumber (parsedCnt) or 0
+                local total = tonumber (liveTotal) or tonumber (parsedTotal) or 0
 
-                local desc, done = self:CalcDesc (qId, n, cnt, total)
-                cur[n] = desc
+                local desc, done = self:CalcDesc (qId, n, cnt, total, cur[n])
 
                 if cnt and total then
                     if cnt > 200 then

--- a/Carbonite.Quests/QuestWindow.lua
+++ b/Carbonite.Quests/QuestWindow.lua
@@ -211,9 +211,28 @@ function Nx.Quest.List:Open()
             end
         end)
     end
+    -- Scenario progress is separate from the quest log. Delves use the
+    -- scenario system too, so UNIT_QUEST_LOG_CHANGED is not enough to keep
+    -- the Carbonite watch current. Gate the registrations by API presence to
+    -- keep Classic clients that do not expose scenarios on the safe path.
+    local hasScenarioAPI = (C_ScenarioInfo and C_ScenarioInfo.GetScenarioInfo)
+        or (C_Scenario and C_Scenario.GetInfo)
+    if hasScenarioAPI then
+        CarboniteQuest:RegisterEvent ("PLAYER_ENTERING_WORLD", "OnQuestUpdate")
+        CarboniteQuest:RegisterEvent ("SCENARIO_UPDATE", "OnQuestUpdate")
+        CarboniteQuest:RegisterEvent ("SCENARIO_CRITERIA_UPDATE", "OnQuestUpdate")
+        CarboniteQuest:RegisterEvent ("SCENARIO_BONUS_VISIBILITY_UPDATE", "OnQuestUpdate")
+        CarboniteQuest:RegisterEvent ("SCENARIO_BONUS_OBJECTIVE_COMPLETE", "OnQuestUpdate")
+        CarboniteQuest:RegisterEvent ("SCENARIO_COMPLETED", "OnQuestUpdate")
+        CarboniteQuest:RegisterEvent ("SCENARIO_CRITERIA_SHOW_STATE_UPDATE", "OnQuestUpdate")
+
+        -- Retail Delves can publish their active state independently of the
+        -- normal SCENARIO_UPDATE event (including after /reload in a Delve).
+        if Nx.isRetail and C_DelvesUI then
+            CarboniteQuest:RegisterEvent ("ACTIVE_DELVE_DATA_UPDATE", "OnQuestUpdate")
+        end
+    end
     --CarboniteQuest:RegisterEvent ("QUEST_WATCH_UPDATE", "OnQuestUpdate")
-    --CarboniteQuest:RegisterEvent ("SCENARIO_UPDATE", "OnQuestUpdate")
-    --CarboniteQuest:RegisterEvent ("SCENARIO_CRITERIA_UPDATE", "OnQuestUpdate")
     CarboniteQuest:RegisterEvent ("WORLD_STATE_TIMER_START", "OnQuestUpdate")
     CarboniteQuest:RegisterEvent ("WORLD_STATE_TIMER_STOP", "OnQuestUpdate")
     --CarboniteQuest:RegisterEvent ("QUEST_POI_UPDATE", "OnQuestUpdate")

--- a/Carbonite.Quests/WatchWindow.lua
+++ b/Carbonite.Quests/WatchWindow.lua
@@ -719,6 +719,247 @@ local function WatchList_ScanTip(bounty)
 end
 
 -------------------------------------------------------------------------------
+-- Scenario compatibility and rendering
+-------------------------------------------------------------------------------
+
+-- C_ScenarioInfo is the current structured API. Keep the tuple-returning
+-- C_Scenario path as a fallback for supported Classic clients and older
+-- branches that have not exposed the structured functions yet.
+local function WatchList_GetScenarioInfo()
+    if C_ScenarioInfo and C_ScenarioInfo.GetScenarioInfo then
+        local info = C_ScenarioInfo.GetScenarioInfo()
+        if info then
+            return info
+        end
+    end
+
+    if C_Scenario and C_Scenario.GetInfo then
+        local name, currentStage, numStages, flags, isComplete = C_Scenario.GetInfo()
+        if name then
+            return {
+                name = name,
+                currentStage = currentStage or 0,
+                numStages = numStages or 0,
+                flags = flags or 0,
+                isComplete = isComplete or false,
+            }
+        end
+    end
+end
+
+local function WatchList_GetScenarioStepInfo(stepID)
+    if C_ScenarioInfo and C_ScenarioInfo.GetScenarioStepInfo then
+        local info = C_ScenarioInfo.GetScenarioStepInfo(stepID)
+        if info then
+            return info
+        end
+    end
+
+    if C_Scenario and C_Scenario.GetStepInfo then
+        local title, description, numCriteria, stepFailed, isBonusStep,
+            isForCurrentStepOnly, shouldShowBonusObjective, _, _,
+            weightedProgress, rewardQuestID, widgetSetID, returnedStepID =
+            C_Scenario.GetStepInfo(stepID)
+        if title then
+            return {
+                title = title,
+                description = description or "",
+                numCriteria = numCriteria or 0,
+                stepFailed = stepFailed or false,
+                isBonusStep = isBonusStep or false,
+                isForCurrentStepOnly = isForCurrentStepOnly or false,
+                shouldShowBonusObjective = shouldShowBonusObjective or false,
+                weightedProgress = weightedProgress,
+                rewardQuestID = rewardQuestID or 0,
+                widgetSetID = widgetSetID,
+                stepID = returnedStepID or stepID,
+            }
+        end
+    end
+end
+
+local function WatchList_GetScenarioCriteriaInfo(criteriaIndex, stepID)
+    if C_ScenarioInfo then
+        local info
+        if stepID and C_ScenarioInfo.GetCriteriaInfoByStep then
+            info = C_ScenarioInfo.GetCriteriaInfoByStep(stepID, criteriaIndex)
+        elseif C_ScenarioInfo.GetCriteriaInfo then
+            info = C_ScenarioInfo.GetCriteriaInfo(criteriaIndex)
+        end
+        if info then
+            return info
+        end
+    end
+
+    if C_Scenario then
+        local getter
+        if stepID and C_Scenario.GetCriteriaInfoByStep then
+            getter = function()
+                return C_Scenario.GetCriteriaInfoByStep(stepID, criteriaIndex)
+            end
+        elseif C_Scenario.GetCriteriaInfo then
+            getter = function()
+                return C_Scenario.GetCriteriaInfo(criteriaIndex)
+            end
+        end
+
+        if getter then
+            local description, criteriaType, completed, quantity, totalQuantity,
+                flags, assetID, quantityString, criteriaID, duration, elapsed,
+                failed, isWeightedProgress, isFormatted = getter()
+            if description then
+                return {
+                    description = description,
+                    criteriaType = criteriaType or 0,
+                    completed = completed or false,
+                    quantity = quantity or 0,
+                    totalQuantity = totalQuantity or 0,
+                    flags = flags or 0,
+                    assetID = assetID or 0,
+                    quantityString = quantityString or "",
+                    criteriaID = criteriaID or 0,
+                    duration = duration or 0,
+                    elapsed = elapsed or 0,
+                    failed = failed or false,
+                    isWeightedProgress = isWeightedProgress or false,
+                    isFormatted = isFormatted or false,
+                }
+            end
+        end
+    end
+end
+
+local function WatchList_FormatScenarioCriteria(info)
+    local description = info.description or ""
+
+    if info.isFormatted then
+        return description
+    end
+
+    if info.isWeightedProgress then
+        local quantityString = info.quantityString
+        if quantityString and quantityString ~= "" then
+            return format("%s %s", quantityString, description)
+        end
+    end
+
+    local quantity = info.quantity or 0
+    local totalQuantity = info.totalQuantity or 0
+    if totalQuantity > 0 then
+        return format("%d/%d %s", quantity, totalQuantity, description)
+    end
+
+    return description
+end
+
+local function WatchList_AddScenarioCriteria(list, info)
+    local text = WatchList_FormatScenarioCriteria(info)
+    local status
+    if info.completed then
+        status = L["Complete"] or "Complete"
+    elseif info.failed then
+        status = FAILED or "Failed"
+    end
+
+    if status then
+        text = format("%s |cffff0000[|cffffffff%s|cffff0000]", text, status)
+    end
+
+    list:ItemAdd(0)
+    list:ItemSetOffset(16, -1)
+    list:ItemSet(2, "|cffffffff" .. text)
+    list:ItemSetButton("QuestWatch", false)
+
+    local duration = info.duration or 0
+    local elapsed = info.elapsed or 0
+    if duration > 0 and elapsed <= duration and not info.completed and not info.failed then
+        list:ItemAdd(0)
+        list:ItemSetOffset(16, -1)
+        list:ItemSet(2, format("|cffffffff%s: %s",
+            L["Time Left"] or "Time Left",
+            Nx.Util_GetTimeElapsedMinSecStr(duration - elapsed)))
+    end
+end
+
+local function WatchList_AddScenario(list)
+    local scenarioInfo = WatchList_GetScenarioInfo()
+    if not scenarioInfo or not scenarioInfo.name or (scenarioInfo.numStages or 0) <= 0 then
+        return false
+    end
+
+    local currentStage = scenarioInfo.currentStage or 0
+    local numStages = scenarioInfo.numStages or 0
+    local scenarioComplete = scenarioInfo.isComplete or currentStage > numStages
+    local stepInfo = WatchList_GetScenarioStepInfo()
+
+    list:ItemAdd(0)
+    list:ItemSet(2, format("|cffff8888%s%s", L["Scenario: "] or "Scenario: ", scenarioInfo.name))
+    if stepInfo and stepInfo.description and stepInfo.description ~= "" then
+        list:ItemSetButtonTip(stepInfo.description)
+    end
+    list:ItemSetButton("QuestWatch", false)
+
+    local stageText
+    if scenarioComplete then
+        stageText = format(" |cffff0000[|cffffffff%s|cffff0000]", L["Complete"] or "Complete")
+    elseif currentStage > 0 then
+        stageText = format(" |cffff0000%s[|cffffffff%d|cffff0000/|cffffffff%d|cffff0000]",
+            L["Stage "] or "Stage ", currentStage, numStages)
+        if stepInfo and stepInfo.title and stepInfo.title ~= "" then
+            stageText = stageText .. ": |cff00ff00" .. stepInfo.title
+        end
+    end
+
+    if stageText then
+        list:ItemAdd(0)
+        list:ItemSet(2, stageText)
+    end
+
+    local shouldShowCriteria = true
+    if C_Scenario and C_Scenario.ShouldShowCriteria then
+        shouldShowCriteria = C_Scenario.ShouldShowCriteria()
+    end
+
+    if shouldShowCriteria and not scenarioComplete and stepInfo then
+        for criteriaIndex = 1, stepInfo.numCriteria or 0 do
+            local criteriaInfo = WatchList_GetScenarioCriteriaInfo(criteriaIndex)
+            if criteriaInfo then
+                WatchList_AddScenarioCriteria(list, criteriaInfo)
+            end
+        end
+    end
+
+    -- Bonus step enumeration remains on C_Scenario in current clients. Render
+    -- each visible step independently so a Delve with more than one bonus
+    -- objective does not collapse them into a single mismatched row.
+    if C_Scenario and C_Scenario.GetBonusSteps then
+        local bonusSteps = C_Scenario.GetBonusSteps() or {}
+        for _, stepID in ipairs(bonusSteps) do
+            local bonusInfo = WatchList_GetScenarioStepInfo(stepID)
+            if bonusInfo then
+                local bonusTitle = bonusInfo.title
+                if not bonusTitle or bonusTitle == "" then
+                    bonusTitle = BONUS_OBJECTIVE or "Bonus Objective"
+                end
+
+                list:ItemAdd(0)
+                list:ItemSet(2, format(" |cffff0000%s: |cff00ff00%s",
+                    BONUS_OBJECTIVE or "Bonus Objective", bonusTitle))
+
+                for criteriaIndex = 1, bonusInfo.numCriteria or 0 do
+                    local criteriaInfo = WatchList_GetScenarioCriteriaInfo(criteriaIndex, stepID)
+                    if criteriaInfo then
+                        WatchList_AddScenarioCriteria(list, criteriaInfo)
+                    end
+                end
+            end
+        end
+    end
+
+    return true
+end
+
+-------------------------------------------------------------------------------
 -- Update watch list
 -------------------------------------------------------------------------------
 
@@ -938,75 +1179,9 @@ function Nx.Quest.Watch:UpdateList()
                       end
                     end
                 end
-                --[[if Nx.qdb.profile.QuestWatch.ScenTrack then
-                    local name, currentStage, numStages = C_Scenario.GetInfo()
-                    if (currentStage > 0) then
-                        local stageName, stageDescription, numCriteria = C_Scenario.GetStepInfo()
-                        list:ItemAdd(0)
-                        list:ItemSet(2,format("|cffff8888" ..L["Scenario: "] .."%s",name))
-                        list:ItemSetButtonTip(stageDescription)
-                        list:ItemSetButton("QuestWatch",false)
-                        if (currentStage <= numStages) then
-                            s = format(" |cffff0000" ..L["Stage "] .."[|cffffffff%d|cffff0000/|cffffffff%d|cffff0000]:|cff00ff00%s", currentStage, numStages,stageName)
-                        else
-                            s = " |cffff0000[|cffffffff" ..L["Complete"] .."|cffff0000]"
-                        end
-                        list:ItemAdd(0)
-                        list:ItemSet(2,s)
-                        for criteria = 1, numCriteria do
-                            local text, _, finished, quantity, totalquantity = C_Scenario.GetCriteriaInfo(criteria)
-                            if finished then
-                                s = format("|cffffffff%d/%d %s |cffff0000[|cffffffff" ..L["Complete"] .."|cffff0000]", quantity, totalquantity, text)
-                            else
-                                s = format("|cffffffff%d/%d %s", quantity, totalquantity, text and text or "")
-                            end
-                            list:ItemAdd(0)
-                            list:ItemSetOffset (16, -1)
-                            list:ItemSet(2,s)
-                            list:ItemSetButton("QuestWatch",false)
-                        end
-                        local bonusSteps = C_Scenario.GetBonusSteps() or {}
-                        if #bonusSteps >= 1 then
-                            local title, task, _, completed = C_Scenario.GetStepInfo(bonusSteps[1])
-                            local tasktexts = { "Bonus |cff00ff00" }
-                            task:gsub('%S+%s*', function(word)
-                                if (#tasktexts[#tasktexts] + #word) < (Nx.qdb.profile.QuestWatch.OMaxLen + 10) then
-                                    tasktexts[#tasktexts] = tasktexts[#tasktexts] .. word
-                                else
-                                    tasktexts[#tasktexts+1] = " |cff00ff00" .. word
-                                end
-                            end)
-                            tasktexts[1] = " |cffff0000" .. tasktexts[1]
-                            if completed then
-                                tasktexts[#tasktexts] = tasktexts[#tasktexts] .. " |cffff0000[|cffffffff" ..L["Complete"] .."|cffff0000]"
-                            end
-                            for i = 1, #tasktexts do
-                                list:ItemAdd(0)
-                                list:ItemSet(2, tasktexts[i])
-                            end
-                            for criteria = 1, #bonusSteps do
-                                local index = bonusSteps[criteria]
-                                local task, criteriatype, completed, quantity, totalquantity, flags, assetid, quantitystring, criteriaid, duration, elapsed, failed, weighted = C_Scenario.GetCriteriaInfoByStep(index,1)
-                                if completed then
-                                    task = format("|cffffffff%d/%d %s |cffff0000[|cffffffff" ..L["Complete"] .."|cffff0000]",quantity, totalquantity, task)
-                                elseif failed then
-                                    task = format("|cffffffff%d/%d %s |cffff0000[|cffffffff" .. L["Failed"] .. "|cffff0000]",quantity, totalquantity, task)
-                                else
-                                    task = format("|cffffffff%d/%d %s",quantity, totalquantity, task)
-                                end
-                                list:ItemAdd(0)
-                                list:ItemSetOffset (16, -1)
-                                list:ItemSet(2,task)
-                                list:ItemSetButton("QuestWatch",false)
-                                if (duration > 0 and elapsed <= duration and not (completed or failed)) then
-                                    list:ItemAdd(0)
-                                    list:ItemSetOffset(16,-1)
-                                    list:ItemSet(2, L["Time Left"] .. ": " .. Nx.Util_GetTimeElapsedMinSecStr(duration - elapsed))
-                                end
-                            end
-                        end
-                    end
-                end]]--
+                if qwProfile.ScenTrack then
+                    WatchList_AddScenario(list)
+                end
                 local tasks = {}
                 -- World quests / bonus tasks feed. The 12.0 engine is unified
                 -- across flavors, but some C_TaskQuest functions are disabled


### PR DESCRIPTION
Changelog:

Restored scenario and Delve objectives in the quest watch frame.
Added scenario stages, criteria, bonus objectives, timers, and completion states.
Added Delve-specific refresh handling and support for reloading inside an active instance.
Added modern scenario API support with compatible legacy fallbacks.
Fixed objectives intermittently displaying duplicate counts, such as 1/1 1/1.
Prevented party synchronization from modifying live objective data.
Normalized shared objective text to display exactly one progress count.
Preserved the configured count-first or count-last display format.