### PR TITLE
Consolidates World Quest tracking and reward inspection and corrects MoP Classic city-map rendering for Undercity #548

### DIFF
--- a/Carbonite.Quests/MapIcons.lua
+++ b/Carbonite.Quests/MapIcons.lua
@@ -820,24 +820,22 @@ function Nx.Quest:UpdateIcons (map)
                                 map.MapId)
                             if not InCombatLockdown() and self.worldQuest then
                                 if not ChatEdit_TryInsertQuestLinkForQuestID(self.questID) then
-                                    -- Capture click-time inputs and
-                                    -- defer the secure mutations to
-                                    -- the next tick via C_Timer.After.
-                                    -- Calling C_SuperTrack.* /
-                                    -- QuestUtil.TrackWorldQuest from
-                                    -- this (Carbonite-tainted) click
-                                    -- stack propagates our taint
+                                    -- Capture click-time inputs and defer the
+                                    -- mutations to the next tick. The actual
+                                    -- C APIs are then invoked through the
+                                    -- secure-call helpers; a timer by itself
+                                    -- still runs as Carbonite and does not
+                                    -- remove execution taint.
+                                    -- Calling C_SuperTrack.* / QuestUtil from
+                                    -- this Carbonite click stack propagates taint
                                     -- through Blizzard's CallbackRegistry
                                     -- super-track chain, which ends at
                                     -- QuestDataProvider:RefreshAllData
                                     -- → AcquirePin → SetPassThroughButtons
                                     -- — a protected call that throws
                                     -- ADDON_ACTION_BLOCKED blaming
-                                    -- Carbonite (typically surfaces on
-                                    -- WQ completion when Blizz auto-
-                                    -- clears the super-track). Running
-                                    -- the block from a fresh timer
-                                    -- callback breaks the chain.
+                                    -- Carbonite (typically surfaces on WQ
+                                    -- completion when Blizzard auto-clears it).
                                     local questID = self.questID
                                     local mapID = self.mapID
                                     local shift = IsShiftKeyDown()
@@ -859,21 +857,21 @@ function Nx.Quest:UpdateIcons (map)
                                         if shift then
                                             if watchType == Enum.QuestWatchType.Manual or (watchType == Enum.QuestWatchType.Automatic and isSuperTracked) then
                                                 PlaySound(SOUNDKIT.IG_MAINMENU_OPTION_CHECKBOX_OFF)
-                                                QuestUtil.UntrackWorldQuest(questID)
+                                                Nx.RemoveWorldQuestWatchSafe(questID)
                                             else
                                                 PlaySound(SOUNDKIT.IG_MAINMENU_OPTION_CHECKBOX_ON)
-                                                QuestUtil.TrackWorldQuest(questID, Enum.QuestWatchType.Manual)
+                                                Nx.AddWorldQuestWatchSafe(questID, Enum.QuestWatchType.Manual)
                                             end
                                         else
                                             if isSuperTracked then
                                                 PlaySound(SOUNDKIT.IG_MAINMENU_OPTION_CHECKBOX_OFF)
-                                                C_SuperTrack.SetSuperTrackedQuestID(0)
+                                                Nx.SetSuperTrackedQuestIDSafe(0)
                                             else
                                                 PlaySound(SOUNDKIT.IG_MAINMENU_OPTION_CHECKBOX_ON)
                                                 if watchType ~= Enum.QuestWatchType.Manual then
-                                                    QuestUtil.TrackWorldQuest(questID, Enum.QuestWatchType.Automatic)
+                                                    Nx.AddWorldQuestWatchSafe(questID, Enum.QuestWatchType.Automatic)
                                                 end
-                                                C_SuperTrack.SetSuperTrackedQuestID(questID)
+                                                Nx.SetSuperTrackedQuestIDSafe(questID)
                                             end
                                         end
                                         end)

--- a/Carbonite.Quests/NxQuest.lua
+++ b/Carbonite.Quests/NxQuest.lua
@@ -245,13 +245,6 @@ if C_QuestLog and C_QuestLog.GetInfo then
     end
 end
 
--- WorldMap_AddQuestTimeToTooltip shim for retail
-if not WorldMap_AddQuestTimeToTooltip and GameTooltip_AddQuestTimeToTooltip then
-    function WorldMap_AddQuestTimeToTooltip(questID)
-        GameTooltip_AddQuestTimeToTooltip(GameTooltip, questID)
-    end
-end
-
 -- GetQuestTagInfo compatibility wrapper.
 -- Retail uses C_QuestLog.GetQuestTagInfo(questID); Classic uses
 -- GetQuestTagInfo(questID). Published on Nx.Quest so extracted
@@ -259,6 +252,25 @@ end
 -- NxQuest sites unchanged.
 Nx.Quest = Nx.Quest or {}
 Nx.Quest.GetQuestCompletionState = GetQuestCompletionState
+
+-- Add quest-time text only to the tooltip explicitly supplied by the caller.
+-- The old Retail compatibility shim always targeted Blizzard's GameTooltip,
+-- even when Carbonite was scanning into Nx.TooltipText. That invisible write
+-- left GameTooltip tainted and later broke AreaPOI widget-set layout when its
+-- height/width values were secret. Older clients without the two-argument API
+-- simply omit this cosmetic scan line instead of touching the global tooltip.
+function Nx.Quest.AddQuestTimeToTooltipCompat(tooltip, questID)
+    if not tooltip then
+        return
+    end
+
+    if GameTooltip_CheckAddQuestTimeToTooltip then
+        GameTooltip_CheckAddQuestTimeToTooltip(tooltip, questID)
+    elseif GameTooltip_AddQuestTimeToTooltip then
+        GameTooltip_AddQuestTimeToTooltip(tooltip, questID)
+    end
+end
+
 function Nx.Quest.GetQuestTagInfoCompat(questID)
     if not questID then return nil end
     if C_QuestLog and C_QuestLog.GetQuestTagInfo then

--- a/Carbonite.Quests/QuestRouting.lua
+++ b/Carbonite.Quests/QuestRouting.lua
@@ -50,7 +50,7 @@ function QuestRouting:ClearActive()
         -- SUPER_TRACKING_CHANGED in our taint and trip the protected
         -- SetPassThroughButtons in Blizzard's QuestDataProvider.
         _G.Nx.SuperTrackSafe(function()
-            _G.C_SuperTrack.SetSuperTrackedQuestID(0)
+            _G.Nx.SetSuperTrackedQuestIDSafe(0)
         end)
     end
     Carbonite.Core.EventBus:Fire("QUEST_ROUTE_CLEARED")

--- a/Carbonite.Quests/QuestWatchSurface.lua
+++ b/Carbonite.Quests/QuestWatchSurface.lua
@@ -43,7 +43,7 @@ function QuestWatchSurface:Track(questID)
         -- SUPER_TRACKING_CHANGED in our taint and trip the protected
         -- SetPassThroughButtons in Blizzard's QuestDataProvider.
         _G.Nx.SuperTrackSafe(function()
-            _G.C_SuperTrack.SetSuperTrackedQuestID(questID)
+            _G.Nx.SetSuperTrackedQuestIDSafe(questID)
         end)
     end
 end
@@ -52,7 +52,7 @@ function QuestWatchSurface:Untrack(questID)
     if _G.C_SuperTrack and _G.C_SuperTrack.SetSuperTrackedQuestID then
         -- Combat-defer (see Track above).
         _G.Nx.SuperTrackSafe(function()
-            _G.C_SuperTrack.SetSuperTrackedQuestID(0)
+            _G.Nx.SetSuperTrackedQuestIDSafe(0)
         end)
     end
     local Quest = _G.Nx and _G.Nx.Quest

--- a/Carbonite.Quests/QuestWindow.lua
+++ b/Carbonite.Quests/QuestWindow.lua
@@ -117,7 +117,7 @@ function Nx.Quest.List:Open()
                         -- moves inside so it's armed right before the call.
                         Nx.SuperTrackSafe(function()
                             Nx.Quest._stSuppressHook = true
-                            C_SuperTrack.SetSuperTrackedQuestID(0)
+                            Nx.SetSuperTrackedQuestIDSafe(0)
                         end)
                     end
                     return
@@ -148,7 +148,7 @@ function Nx.Quest.List:Open()
                     Nx.SuperTrackSafe(function()
                         Nx.Quest._stSuppressHook = true
                         Nx.Quest.UserClearedActive = true
-                        C_SuperTrack.SetSuperTrackedQuestID(0)
+                        Nx.SetSuperTrackedQuestIDSafe(0)
                         -- Blizzard quest area blob is drawn into a
                         -- separate WorldMapBlobFrame (QMap.QuestWin) and
                         -- doesn't auto-hide on super-track clear; do it
@@ -1372,7 +1372,7 @@ function Nx.Quest.List:ToggleWatch (qId, qIndex, qObj, shift)
                 -- the closure so it's set when the call actually fires.
                 Nx.SuperTrackSafe(function()
                     Quest.UserClearedActive = true
-                    C_SuperTrack.SetSuperTrackedQuestID(0)
+                    Nx.SetSuperTrackedQuestIDSafe(0)
                 end)
                 Quest.ActiveQID = 0
                 Quest.ActiveObjI = 0
@@ -1391,7 +1391,7 @@ function Nx.Quest.List:ToggleWatch (qId, qIndex, qObj, shift)
                 end
                 local _live = liveQID
                 Nx.SuperTrackSafe(function()
-                    C_SuperTrack.SetSuperTrackedQuestID(_live)
+                    Nx.SetSuperTrackedQuestIDSafe(_live)
                 end)
                 Quest.ActiveObjI = qObj
                 if qObj > 0 and Quest.TrackOnMap then
@@ -1776,12 +1776,12 @@ function CarboniteQuest:OnQuestUpdate (event, ...)
                 if (C_SuperTrack.GetSuperTrackedQuestID() or 0) ~= 0 then
                     return        -- something got tracked in the meantime
                 end
-                if QuestUtil and QuestUtil.TrackWorldQuest and Enum and Enum.QuestWatchType
+                if Nx.AddWorldQuestWatchSafe and Enum and Enum.QuestWatchType
                    and C_QuestLog and C_QuestLog.GetQuestWatchType
                    and C_QuestLog.GetQuestWatchType(questId) ~= Enum.QuestWatchType.Manual then
-                    QuestUtil.TrackWorldQuest(questId, Enum.QuestWatchType.Automatic)
+                    Nx.AddWorldQuestWatchSafe(questId, Enum.QuestWatchType.Automatic)
                 end
-                C_SuperTrack.SetSuperTrackedQuestID(questId)
+                Nx.SetSuperTrackedQuestIDSafe(questId)
             end)
         end
 
@@ -1801,7 +1801,7 @@ function CarboniteQuest:OnQuestUpdate (event, ...)
                 -- tainted SUPER_TRACKING_CHANGED chain trips the
                 -- combat-protected SetPassThroughButtons.
                 Nx.SuperTrackSafe(function()
-                    C_SuperTrack.SetSuperTrackedQuestID(0)
+                    Nx.SetSuperTrackedQuestIDSafe(0)
                 end)
             end
             -- Drop the Goto route if it was pointing at this WQ. Icon
@@ -1838,7 +1838,7 @@ function CarboniteQuest:OnQuestUpdate (event, ...)
                     -- at fire time in case the super-track moved on.
                     Nx.SuperTrackSafe(function()
                         if C_SuperTrack.GetSuperTrackedQuestID() == questId then
-                            C_SuperTrack.SetSuperTrackedQuestID(0)
+                            Nx.SetSuperTrackedQuestIDSafe(0)
                         end
                     end)
                 end

--- a/Carbonite.Quests/SuperTrack.lua
+++ b/Carbonite.Quests/SuperTrack.lua
@@ -631,7 +631,7 @@ function Nx.Quest:OnSuperTrackChanged()
             -- secure API from our taint trips the combat-protected
             -- SetPassThroughButtons in the QuestDataProvider chain.
             Nx.SuperTrackSafe(function()
-                C_SuperTrack.SetSuperTrackedQuestID(prev)
+                Nx.SetSuperTrackedQuestIDSafe(prev)
             end)
             return
         end
@@ -822,4 +822,3 @@ function Nx.Quest:FinishQuest()
     self.Watch:Update()
     self.WQList:Update()
 end
-

--- a/Carbonite.Quests/WatchWindow.lua
+++ b/Carbonite.Quests/WatchWindow.lua
@@ -452,7 +452,7 @@ function Nx.Quest.Watch:Menu_OnSetActive (item)
         -- SUPER_TRACKING_CHANGED in our taint and trip the protected
         -- SetPassThroughButtons in Blizzard's QuestDataProvider.
         Nx.SuperTrackSafe(function()
-            C_SuperTrack.SetSuperTrackedQuestID(qId)
+            Nx.SetSuperTrackedQuestIDSafe(qId)
         end)
         return
     end
@@ -675,7 +675,9 @@ local function WatchList_ScanTip(bounty)
         if scanTip.ItemTooltip then scanTip.ItemTooltip:Hide() end
 
         scanTip:SetText(title, HIGHLIGHT_FONT_COLOR:GetRGB())
-        WorldMap_AddQuestTimeToTooltip(bounty.questID)
+        if Nx.Quest.AddQuestTimeToTooltipCompat then
+            Nx.Quest.AddQuestTimeToTooltipCompat(scanTip, bounty.questID)
+        end
 
         local _, questDescription = GetQuestLogQuestText(questIndex)
         scanTip:AddLine(questDescription, NORMAL_FONT_COLOR.r, NORMAL_FONT_COLOR.g, NORMAL_FONT_COLOR.b, true)
@@ -965,17 +967,46 @@ local function WatchList_AddScenario(list)
     return true
 end
 
--- Add a world quest that Blizzard is watching even when it is outside the
--- player's current map and therefore absent from C_TaskQuest.GetQuestsOnMap.
--- The normal current-map and quest-log paths below remain unchanged; this is
--- the missing third source needed by the World Quest List's manual watches.
-local function WatchList_AddWatchedWorldQuest(list, questId)
+-- Queue every world-quest feed into one ordered section. Current-map tasks,
+-- quest-log task fallbacks, and manually watched off-map quests can report the
+-- same quest, so use the quest ID as the stable de-duplication key.
+local function WatchList_QueueWorldQuest(
+    worldQuests,
+    queuedQuestIDs,
+    questId,
+    title,
+    numObjectives
+)
     if type(questId) ~= "number" or questId <= 0 then
         return false
     end
 
-    local title
-    if C_TaskQuest and C_TaskQuest.GetQuestInfoByQuestID then
+    if queuedQuestIDs[questId] then
+        return false
+    end
+
+    queuedQuestIDs[questId] = true
+    worldQuests[#worldQuests + 1] = {
+        questId = questId,
+        title = title,
+        numObjectives = numObjectives,
+    }
+    return true
+end
+
+local function WatchList_AddTaskQuestRows(
+    list,
+    questId,
+    title,
+    numObjectives,
+    titleRowID
+)
+    if type(questId) ~= "number" or questId <= 0 then
+        return false
+    end
+
+    if (not title or title == "")
+        and C_TaskQuest and C_TaskQuest.GetQuestInfoByQuestID then
         title = C_TaskQuest.GetQuestInfoByQuestID(questId)
     end
     if (not title or title == "")
@@ -983,17 +1014,20 @@ local function WatchList_AddWatchedWorldQuest(list, questId)
         title = C_QuestLog.GetTitleForQuestID(questId)
     end
 
-    list:ItemAdd(0)
-    list:ItemSet(2, "|cffff00ff----[ |cffffff00" .. L["WORLD QUEST"] .. " |cffff00ff]----")
-    list:ItemAdd(questId * 0x10000)
+    if type(titleRowID) ~= "number" then
+        titleRowID = questId * 0x10000
+    end
+    list:ItemAdd(titleRowID)
     list:ItemSet(
         2,
         Nx.Util_str2colstr(Nx.qdb.profile.QuestWatch.OIncompleteColor)
             .. (title or L["Retrieving data"] or "")
     )
 
-    local numObjectives = C_QuestLog and C_QuestLog.GetNumQuestObjectives
-        and C_QuestLog.GetNumQuestObjectives(questId)
+    if type(numObjectives) ~= "number" then
+        numObjectives = C_QuestLog and C_QuestLog.GetNumQuestObjectives
+            and C_QuestLog.GetNumQuestObjectives(questId)
+    end
     if type(numObjectives) == "number" and numObjectives > 0 then
         for objectiveIndex = 1, numObjectives do
             local text, objectiveType =
@@ -1001,7 +1035,8 @@ local function WatchList_AddWatchedWorldQuest(list, questId)
             if objectiveType == "progressbar" then
                 list:ItemAdd(0)
                 list:ItemSetOffset(16, -1)
-                local percent = C_TaskQuest.GetQuestProgressBarInfo
+                local percent = C_TaskQuest
+                    and C_TaskQuest.GetQuestProgressBarInfo
                     and C_TaskQuest.GetQuestProgressBarInfo(questId) or 0
                 if Nx.qdb.profile.QuestWatch.BonusBar then
                     local filled = floor(percent)
@@ -1031,6 +1066,31 @@ local function WatchList_AddWatchedWorldQuest(list, questId)
                 list:ItemSet(2, "|cff00ff00" .. text)
             end
         end
+    end
+
+    return true
+end
+
+local function WatchList_AddWorldQuestSection(list, worldQuests)
+    if #worldQuests == 0 then
+        return false
+    end
+
+    list:ItemAdd(0)
+    list:ItemSet(
+        2,
+        "|cffff00ff----[ |cffffff00"
+            .. L["WORLD QUEST"]
+            .. " |cffff00ff]----"
+    )
+
+    for _, worldQuest in ipairs(worldQuests) do
+        WatchList_AddTaskQuestRows(
+            list,
+            worldQuest.questId,
+            worldQuest.title,
+            worldQuest.numObjectives
+        )
     end
 
     list:ItemAdd(0)
@@ -1266,6 +1326,8 @@ function Nx.Quest.Watch:UpdateList()
                     WatchList_AddScenario(list)
                 end
                 local tasks = {}
+                local worldQuests = {}
+                local queuedWorldQuestIDs = {}
                 local watchedWorldQuestIDs = {}
                 local watchedWorldQuests = {}
 
@@ -1317,51 +1379,25 @@ function Nx.Quest.Watch:UpdateList()
                                 local rarity = questTagInfo and questTagInfo.quality
                                 local isElite = questTagInfo and questTagInfo.isElite
                                 local tradeskillLineIndex = questTagInfo and questTagInfo.tradeskillLineID
-                                local task_title = L["BONUS TASK"]
-                                if worldQuestType ~= nil then task_title = L["WORLD QUEST"] end
-                                list:ItemAdd(0)
-                                list:ItemSet(2,"|cffff00ff----[ |cffffff00" .. task_title .. " |cffff00ff]----")
-                                list:ItemAdd(questId * 0x10000 + 0)
-                                list:ItemSet(2,Nx.Util_str2colstr (Nx.qdb.profile.QuestWatch.OIncompleteColor) .. (title or ""))
-                                --local _,x,y = QuestPOIGetIconInfo(questId)
-                                --Nx.prt("====%s: %s, %s", title, x, y)
-                                if numObjectives and numObjectives > 0 then
-                                    for j=1,numObjectives do
-                                        local text, objectiveType, finished = GetQuestObjectiveInfo (questId, j, false)
-                                        if objectiveType == "progressbar" then
-                                            list:ItemAdd(0)
-                                            list:ItemSetOffset (16, -1)
-                                            local percent = C_TaskQuest.GetQuestProgressBarInfo(questId) or 0
-                                            if Nx.qdb.profile.QuestWatch.BonusBar then
-                                                -- Two-segment bar: filled (B) + remainder (BG).
-                                                -- Always 100px wide so the bar's full extent
-                                                -- is visible even at low percentages.
-                                                local filled = math.floor(percent)
-                                                local empty  = 100 - filled
-                                                local bar = ""
-                                                if filled > 0 then
-                                                    bar = format(" |TInterface\\Addons\\Carbonite\\Gfx\\Skin\\InfoBarB:12:%d:|t", filled)
-                                                else
-                                                    bar = " "
-                                                end
-                                                if empty > 0 then
-                                                    bar = bar .. format("|TInterface\\Addons\\Carbonite\\Gfx\\Skin\\InfoBarBG:12:%d:|t", empty)
-                                                end
-                                                list:ItemSet(2, format("%s %.2f%%", bar, percent))
-                                            else
-                                                list:ItemSet(2,format("|cff00ff00%s %.2f%%", L["Progress: "], percent))
-                                            end
-                                        else
-                                            list:ItemAdd(0)
-                                            list:ItemSetOffset (16, -1)
-                                            list:ItemSet(2,"|cff00ff00" .. text)
-                                        end
-                                    end
-                                end
-                                list:ItemAdd(0)
                                 if worldQuestType ~= nil then
-                                    list:ItemSet(2,"|cffff00ff------------------------------")
+                                    WatchList_QueueWorldQuest(
+                                        worldQuests,
+                                        queuedWorldQuestIDs,
+                                        questId,
+                                        title,
+                                        numObjectives
+                                    )
                                 else
+                                    list:ItemAdd(0)
+                                    list:ItemSet(2,"|cffff00ff----[ |cffffff00" .. L["BONUS TASK"] .. " |cffff00ff]----")
+                                    WatchList_AddTaskQuestRows(
+                                        list,
+                                        questId,
+                                        title,
+                                        numObjectives,
+                                        questId * 0x10000
+                                    )
+                                    list:ItemAdd(0)
                                     list:ItemSet(2,"|cffff00ff----------------------------")
                                 end
                             end
@@ -1381,49 +1417,29 @@ function Nx.Quest.Watch:UpdateList()
                                 local rarity = questTagInfo and questTagInfo.quality
                                 local isElite = questTagInfo and questTagInfo.isElite
                                 local tradeskillLineIndex = questTagInfo and questTagInfo.tradeskillLineID
-                                local task_title = L["BONUS TASK"]
-                                if worldQuestType ~= nil then task_title = L["WORLD QUEST"] end
-                                list:ItemAdd(0)
-                                list:ItemSet(2,"|cffff00ff----[ |cffffff00" .. task_title .. " |cffff00ff]----")
-                                list:ItemAdd(0)
-                                list:ItemSet(2,Nx.Util_str2colstr (Nx.qdb.profile.QuestWatch.OIncompleteColor) .. (title or ""))
                                 local numObjectives = C_QuestLog and C_QuestLog.GetNumQuestObjectives
                                     and C_QuestLog.GetNumQuestObjectives(questId)
-                                if numObjectives and numObjectives > 0 then
-                                    for j=1,numObjectives do
-                                        local text, objectiveType, finished = GetQuestObjectiveInfo (questId, j, false)
-                                        if objectiveType == "progressbar" then
-                                            list:ItemAdd(0)
-                                            list:ItemSetOffset (16, -1)
-                                            local percent = C_TaskQuest.GetQuestProgressBarInfo(questId) or 0
-                                            if Nx.qdb.profile.QuestWatch.BonusBar then
-                                                -- Two-segment bar: filled (B) + remainder (BG).
-                                                -- Always 100px wide so the bar's full extent
-                                                -- is visible even at low percentages.
-                                                local filled = math.floor(percent)
-                                                local empty  = 100 - filled
-                                                local bar = ""
-                                                if filled > 0 then
-                                                    bar = format(" |TInterface\\Addons\\Carbonite\\Gfx\\Skin\\InfoBarB:12:%d:|t", filled)
-                                                else
-                                                    bar = " "
-                                                end
-                                                if empty > 0 then
-                                                    bar = bar .. format("|TInterface\\Addons\\Carbonite\\Gfx\\Skin\\InfoBarBG:12:%d:|t", empty)
-                                                end
-                                                list:ItemSet(2, format("%s %.2f%%", bar, percent))
-                                            else
-                                                list:ItemSet(2,format("|cff00ff00%s %.2f%%", L["Progress: "], percent))
-                                            end
-                                        else
-                                            list:ItemAdd(0)
-                                            list:ItemSetOffset (16, -1)
-                                            list:ItemSet(2,"|cff00ff00" .. text)
-                                        end
-                                    end
+                                if worldQuestType ~= nil then
+                                    WatchList_QueueWorldQuest(
+                                        worldQuests,
+                                        queuedWorldQuestIDs,
+                                        questId,
+                                        title,
+                                        numObjectives
+                                    )
+                                else
+                                    list:ItemAdd(0)
+                                    list:ItemSet(2,"|cffff00ff----[ |cffffff00" .. L["BONUS TASK"] .. " |cffff00ff]----")
+                                    WatchList_AddTaskQuestRows(
+                                        list,
+                                        questId,
+                                        title,
+                                        numObjectives,
+                                        0
+                                    )
+                                    list:ItemAdd(0)
+                                    list:ItemSet(2,"|cffff00ff-------------------------------")
                                 end
-                                list:ItemAdd(0)
-                                list:ItemSet(2,"|cffff00ff-------------------------------")
                             end
                         end
                     end
@@ -1435,9 +1451,18 @@ function Nx.Quest.Watch:UpdateList()
                     for _, questId in ipairs(watchedWorldQuestIDs) do
                         if tasks[questId] ~= true then
                             tasks[questId] = true
-                            WatchList_AddWatchedWorldQuest(list, questId)
+                            WatchList_QueueWorldQuest(
+                                worldQuests,
+                                queuedWorldQuestIDs,
+                                questId
+                            )
                         end
                     end
+
+                    -- Emit one shared section after all three feeds have been
+                    -- merged. Individual world quests keep their own title and
+                    -- objectives, but no longer repeat the section header.
+                    WatchList_AddWorldQuestSection(list, worldQuests)
                 end
                 if Nx.qdb.profile.QuestWatch.AchTrack then
                     local achs = Nx.Quest.TrackedAchievements
@@ -1922,10 +1947,10 @@ function Nx.Quest.Watch:OnListEvent (eventName, val1, val2, click, but)
                         if C_SuperTrack.SetSuperTrackedUserWaypoint
                            and C_SuperTrack.IsSuperTrackingUserWaypoint
                            and C_SuperTrack.IsSuperTrackingUserWaypoint() then
-                            C_SuperTrack.SetSuperTrackedUserWaypoint(false)
+                            Nx.SetSuperTrackedUserWaypointSafe(false)
                         end
                         if C_SuperTrack.ClearAllSuperTracked then
-                            C_SuperTrack.ClearAllSuperTracked()
+                            Nx.ClearAllSuperTrackedSafe()
                         end
                         -- Will trigger our SetSuperTrackedQuestID hook. If that
                         -- hook toggles off (clicking the active quest again), it
@@ -1933,7 +1958,7 @@ function Nx.Quest.Watch:OnListEvent (eventName, val1, val2, click, but)
                         -- to remember the toggle happened so the rest of this
                         -- handler doesn't immediately re-add tracking via
                         -- Watch:Set (which would put the arrow right back).
-                        C_SuperTrack.SetSuperTrackedQuestID(liveQID)
+                        Nx.SetSuperTrackedQuestIDSafe(liveQID)
                     end)
                     if Quest._stLockoutUntil and GetTime
                        and GetTime() < Quest._stLockoutUntil then

--- a/Carbonite.Quests/WorldQuestWindow.lua
+++ b/Carbonite.Quests/WorldQuestWindow.lua
@@ -9,16 +9,22 @@ if not Nx then return end
 Nx.Quest = Nx.Quest or {}
 Nx.Quest.WQList = Nx.Quest.WQList or {}
 
+local C_CurrencyInfo = _G.C_CurrencyInfo
 local C_Item = _G.C_Item
+local C_MajorFactions = _G.C_MajorFactions
 local C_Map = _G.C_Map
 local C_QuestLog = _G.C_QuestLog
+local C_QuestInfoSystem = _G.C_QuestInfoSystem
 local C_Reputation = _G.C_Reputation
 local C_TaskQuest = _G.C_TaskQuest
 local C_Timer = _G.C_Timer
+local C_TooltipComparison = _G.C_TooltipComparison
+local C_TooltipInfo = _G.C_TooltipInfo
 local Enum = _G.Enum
-local QuestUtil = _G.QuestUtil
 
+local BreakUpLargeNumbers = _G.BreakUpLargeNumbers
 local GetFactionInfoByID = _G.GetFactionInfoByID
+local GetMoneyString = _G.GetMoneyString
 local GetNumQuestLogRewardCurrencies = _G.GetNumQuestLogRewardCurrencies
 local GetNumQuestLogRewards = _G.GetNumQuestLogRewards
 local GetQuestLogRewardArtifactXP = _G.GetQuestLogRewardArtifactXP
@@ -34,13 +40,16 @@ local QuestUtils_IsQuestWorldQuest = _G.QuestUtils_IsQuestWorldQuest
 local format = string.format
 local ipairs = ipairs
 local issecretvalue = _G.issecretvalue
+local floor = math.floor
 local max = math.max
 local min = math.min
 local pairs = pairs
+local pcall = pcall
 local sort = table.sort
 local tconcat = table.concat
 local tinsert = table.insert
 local tonumber = tonumber
+local tostring = tostring
 local type = type
 local wipe = _G.wipe
 
@@ -60,10 +69,10 @@ local MAX_SCAN_MAPS = 128
 local REFRESH_DELAY_SECONDS = 0.20
 local REWARD_REQUEST_RETRY_SECONDS = 5
 local MAX_EXPIRY_TIMER_SECONDS = 86400
-local WINDOW_LAYOUT_VERSION = 2
-local WINDOW_MIN_WIDTH = 480
+local WINDOW_LAYOUT_VERSION = 3
+local WINDOW_MIN_WIDTH = 600
 local WINDOW_MIN_HEIGHT = 180
-local WINDOW_DEFAULT_WIDTH = 620
+local WINDOW_DEFAULT_WIDTH = 760
 local WINDOW_DEFAULT_HEIGHT = 360
 
 local UI_MAP_TYPE_CONTINENT = Enum and Enum.UIMapType and Enum.UIMapType.Continent or 2
@@ -74,6 +83,22 @@ local ITEM_CLASS_TRADEGOODS = Enum and Enum.ItemClass and Enum.ItemClass.Tradego
 local QUEST_TAG_PVP = Enum and Enum.QuestTagType and Enum.QuestTagType.PvP or 3
 local QUEST_WATCH_MANUAL = Enum and Enum.QuestWatchType
     and Enum.QuestWatchType.Manual or 1
+local TOOLTIP_LINE_ITEM_NAME = Enum and Enum.TooltipDataLineType
+    and Enum.TooltipDataLineType.ItemName or 22
+local TOOLTIP_LINE_ITEM_LEVEL = Enum and Enum.TooltipDataLineType
+    and Enum.TooltipDataLineType.ItemLevel or 31
+local TOOLTIP_LINE_SELL_PRICE = Enum and Enum.TooltipDataLineType
+    and Enum.TooltipDataLineType.SellPrice or 11
+local TOOLTIP_DATA_ITEM = Enum and Enum.TooltipDataType
+    and Enum.TooltipDataType.Item or 0
+local TOOLTIP_COMPARISON_SINGLE = Enum and Enum.TooltipComparisonMethod
+    and Enum.TooltipComparisonMethod.Single or 0
+local TOOLTIP_COMPARISON_BOTH_HANDS = Enum and Enum.TooltipComparisonMethod
+    and Enum.TooltipComparisonMethod.WithBothHands or 1
+local TOOLTIP_COMPARISON_BAG_MAIN_HAND = Enum and Enum.TooltipComparisonMethod
+    and Enum.TooltipComparisonMethod.WithBagMainHandItem or 2
+local TOOLTIP_COMPARISON_BAG_OFF_HAND = Enum and Enum.TooltipComparisonMethod
+    and Enum.TooltipComparisonMethod.WithBagOffHandItem or 3
 
 local REWARD_ORDER = {
     { key = "gear", label = "Gear", option = "showgear" },
@@ -344,6 +369,442 @@ local function HasKnownReward(flags)
     return false
 end
 
+local function FormatRewardAmount(amount)
+    if not IsSafeNumber(amount) then
+        return
+    end
+
+    if BreakUpLargeNumbers then
+        local amountText = BreakUpLargeNumbers(amount)
+        if IsSafeString(amountText) and amountText ~= "" then
+            return amountText
+        end
+    end
+
+    return tostring(amount)
+end
+
+local function BuildRewardTextureMarkup(texture)
+    local textureText
+    if IsSafeNumber(texture) then
+        textureText = tostring(texture)
+    elseif IsSafeString(texture) and texture ~= "" then
+        textureText = texture
+    end
+
+    if textureText then
+        return "|T" .. textureText .. ":14:14|t"
+    end
+end
+
+local function AddRewardText(details, rowText, texture)
+    if not IsSafeString(rowText) or rowText == "" then
+        return false
+    end
+
+    local textureMarkup = BuildRewardTextureMarkup(texture)
+    details[#details + 1] = {
+        rowText = rowText,
+        tooltipText = textureMarkup and textureMarkup .. " " .. rowText or rowText,
+    }
+    return true
+end
+
+local function AddNamedReward(details, name, amount, texture, showSingleAmount)
+    if not IsSafeString(name) or name == "" then
+        return false
+    end
+
+    local rowText = name
+    if IsSafeNumber(amount) and amount > 0
+        and (showSingleAmount or amount > 1) then
+        local amountText = FormatRewardAmount(amount)
+        if amountText then
+            rowText = amountText .. " " .. name
+        end
+    end
+
+    return AddRewardText(details, rowText, texture)
+end
+
+local function ColorizeTooltipText(text, color)
+    if not IsSafeString(text) or text == "" then
+        return
+    end
+
+    if not IsSafeValue(color) or type(color) ~= "table" then
+        return text
+    end
+
+    local red = color.r
+    local green = color.g
+    local blue = color.b
+    if not IsSafeNumber(red) or not IsSafeNumber(green) or not IsSafeNumber(blue) then
+        return text
+    end
+
+    red = floor(min(1, max(0, red)) * 255 + 0.5)
+    green = floor(min(1, max(0, green)) * 255 + 0.5)
+    blue = floor(min(1, max(0, blue)) * 255 + 0.5)
+    return format("|cff%02x%02x%02x%s|r", red, green, blue, text)
+end
+
+local function BuildItemTooltipLine(lineData, itemName)
+    if not IsSafeValue(lineData) or type(lineData) ~= "table" then
+        return
+    end
+
+    local lineType = lineData.type
+    if IsSafeNumber(lineType) and lineType == TOOLTIP_LINE_ITEM_NAME then
+        return
+    end
+
+    local leftText = IsSafeString(lineData.leftText) and lineData.leftText or nil
+    local rightText = IsSafeString(lineData.rightText) and lineData.rightText or nil
+
+    -- The reward line already contains the item name and quantity.
+    if leftText and not rightText and IsSafeString(itemName) and leftText == itemName then
+        return
+    end
+
+    -- Blizzard renders SellPrice as a money frame after the data line. Fold
+    -- that value into text because Carbonite intentionally uses a private,
+    -- string-backed tooltip instead of Blizzard's reward tooltip frames.
+    if IsSafeNumber(lineType) and lineType == TOOLTIP_LINE_SELL_PRICE
+        and IsSafeNumber(lineData.price) and lineData.price > 0
+        and GetMoneyString then
+        local moneyText = GetMoneyString(lineData.price, true)
+        if IsSafeString(moneyText) and moneyText ~= "" then
+            local sellPriceText = leftText
+            if not sellPriceText or sellPriceText == "" then
+                sellPriceText = IsSafeString(_G.SELL_PRICE) and _G.SELL_PRICE or "Sell Price:"
+            end
+            leftText = sellPriceText .. " " .. moneyText
+        end
+    end
+
+    leftText = ColorizeTooltipText(leftText, lineData.leftColor)
+    rightText = ColorizeTooltipText(rightText, lineData.rightColor)
+
+    if leftText and rightText then
+        -- Nx:SetTooltipText interprets a tab as a true two-column tooltip row.
+        return leftText .. "\t" .. rightText
+    end
+    return leftText or rightText
+end
+
+local function GetQuestRewardItemTooltipLines(questID, rewardIndex, itemName)
+    if not C_TooltipInfo or type(C_TooltipInfo.GetQuestLogItem) ~= "function"
+        or not IsSafeNumber(questID) or not IsSafeNumber(rewardIndex) then
+        return nil, true
+    end
+
+    -- This is the read-only data source used by Blizzard's full world-quest
+    -- item tooltip. It does not mutate GameTooltip, UI widgets, or map pins.
+    local succeeded, tooltipData = pcall(
+        C_TooltipInfo.GetQuestLogItem,
+        "reward",
+        rewardIndex,
+        questID,
+        true
+    )
+    if not succeeded then
+        return nil, true
+    end
+    if not tooltipData then
+        return nil, false
+    end
+    if not IsSafeValue(tooltipData) or type(tooltipData) ~= "table"
+        or not IsSafeValue(tooltipData.lines) or type(tooltipData.lines) ~= "table" then
+        return nil, true
+    end
+
+    local lines = {}
+    for _, lineData in ipairs(tooltipData.lines) do
+        local line = BuildItemTooltipLine(lineData, itemName)
+        if line then
+            lines[#lines + 1] = line
+        end
+    end
+    return lines, true, tooltipData
+end
+
+local function CopyTooltipComparisonItem(item)
+    if not IsSafeValue(item) or type(item) ~= "table" then
+        return
+    end
+
+    local comparisonItem
+    if IsSafeString(item.guid) and item.guid ~= "" then
+        comparisonItem = { guid = item.guid }
+    elseif IsSafeString(item.hyperlink) and item.hyperlink ~= "" then
+        comparisonItem = { hyperlink = item.hyperlink }
+    end
+
+    if comparisonItem and IsSafeNumber(item.overrideItemLevel) then
+        comparisonItem.overrideItemLevel = item.overrideItemLevel
+    end
+    return comparisonItem
+end
+
+local function CreateTooltipComparisonItem(tooltipData)
+    if not IsSafeValue(tooltipData) or type(tooltipData) ~= "table"
+        or not IsSafeNumber(tooltipData.type)
+        or tooltipData.type ~= TOOLTIP_DATA_ITEM then
+        return
+    end
+
+    return CopyTooltipComparisonItem(tooltipData)
+end
+
+local function GetTooltipComparisonItemKey(item)
+    if type(item) ~= "table" then
+        return
+    end
+    if IsSafeString(item.guid) and item.guid ~= "" then
+        return "guid:" .. item.guid
+    end
+    if IsSafeString(item.hyperlink) and item.hyperlink ~= "" then
+        return "link:" .. item.hyperlink
+    end
+end
+
+local function GetTooltipComparisonItemData(item)
+    if not C_TooltipInfo or type(item) ~= "table" then
+        return
+    end
+
+    local getter
+    local itemKey
+    if IsSafeString(item.guid) and item.guid ~= ""
+        and type(C_TooltipInfo.GetItemByGUID) == "function" then
+        getter = C_TooltipInfo.GetItemByGUID
+        itemKey = item.guid
+    elseif IsSafeString(item.hyperlink) and item.hyperlink ~= ""
+        and type(C_TooltipInfo.GetHyperlink) == "function" then
+        getter = C_TooltipInfo.GetHyperlink
+        itemKey = item.hyperlink
+    end
+
+    if not getter then
+        return
+    end
+
+    local succeeded, tooltipData = pcall(getter, itemKey)
+    if not succeeded or not IsSafeValue(tooltipData)
+        or type(tooltipData) ~= "table" then
+        return
+    end
+    return tooltipData
+end
+
+local function GetTooltipComparisonItemSummary(item)
+    local tooltipData = GetTooltipComparisonItemData(item)
+    if not tooltipData or not IsSafeValue(tooltipData.lines)
+        or type(tooltipData.lines) ~= "table" then
+        return
+    end
+
+    local itemName
+    local itemLevel
+    for _, lineData in ipairs(tooltipData.lines) do
+        if IsSafeValue(lineData) and type(lineData) == "table" then
+            local lineType = lineData.type
+            if IsSafeNumber(lineType) and lineType == TOOLTIP_LINE_ITEM_NAME
+                and IsSafeString(lineData.leftText)
+                and lineData.leftText ~= "" then
+                itemName = ColorizeTooltipText(lineData.leftText, lineData.leftColor)
+            elseif IsSafeNumber(lineType) and lineType == TOOLTIP_LINE_ITEM_LEVEL then
+                itemLevel = BuildItemTooltipLine(lineData)
+            end
+        end
+    end
+
+    return itemName, itemLevel
+end
+
+local function GetTooltipComparisonDelta(
+    comparisonItem,
+    equippedItem,
+    pairedItem,
+    addPairedStats
+)
+    if not C_TooltipComparison
+        or type(C_TooltipComparison.GetItemComparisonDelta) ~= "function" then
+        return
+    end
+
+    local succeeded, deltaLines = pcall(
+        C_TooltipComparison.GetItemComparisonDelta,
+        comparisonItem,
+        equippedItem,
+        pairedItem,
+        addPairedStats
+    )
+    if not succeeded or not IsSafeValue(deltaLines)
+        or type(deltaLines) ~= "table" then
+        return
+    end
+
+    local safeLines = {}
+    for _, deltaLine in ipairs(deltaLines) do
+        if IsSafeString(deltaLine) and deltaLine ~= "" then
+            safeLines[#safeLines + 1] = deltaLine
+        end
+    end
+    return safeLines
+end
+
+local function AddTooltipComparisonItemSummary(lines, item, headerText)
+    local itemName, itemLevel = GetTooltipComparisonItemSummary(item)
+    if not itemName and not itemLevel then
+        return false
+    end
+
+    headerText = IsSafeString(headerText) and headerText ~= ""
+        and headerText or "Equipped"
+    if itemName then
+        lines[#lines + 1] = "|cffffd100" .. headerText .. "|r: " .. itemName
+    else
+        lines[#lines + 1] = "|cffffd100" .. headerText .. "|r"
+    end
+    if itemLevel then
+        lines[#lines + 1] = "  " .. itemLevel
+    end
+    return true
+end
+
+local function AddTooltipComparisonDelta(lines, deltaLines, multipleItems)
+    if type(deltaLines) ~= "table" or #deltaLines == 0 then
+        return false
+    end
+
+    local summaryHeader
+    if multipleItems then
+        summaryHeader = _G.ITEM_DELTA_MULTIPLE_COMPARISON_DESCRIPTION
+    else
+        summaryHeader = _G.ITEM_DELTA_DESCRIPTION
+    end
+    if not IsSafeString(summaryHeader) or summaryHeader == "" then
+        summaryHeader = multipleItems
+            and "If you replace these items, the following stat changes will occur:"
+            or "If you replace this item, the following stat changes will occur:"
+    end
+
+    lines[#lines + 1] = "|cffffd100" .. summaryHeader .. "|r"
+    for _, deltaLine in ipairs(deltaLines) do
+        lines[#lines + 1] = "  " .. deltaLine
+    end
+    return true
+end
+
+local function GetQuestRewardItemComparisonLines(tooltipData)
+    if not C_TooltipComparison
+        or type(C_TooltipComparison.GetItemComparisonInfo) ~= "function" then
+        return
+    end
+
+    local comparisonItem = CreateTooltipComparisonItem(tooltipData)
+    if not comparisonItem then
+        return
+    end
+
+    local succeeded, comparisonInfo = pcall(
+        C_TooltipComparison.GetItemComparisonInfo,
+        comparisonItem
+    )
+    if not succeeded or not IsSafeValue(comparisonInfo)
+        or type(comparisonInfo) ~= "table" then
+        return
+    end
+
+    local comparisonMethod = comparisonInfo.method
+    if not IsSafeNumber(comparisonMethod)
+        or comparisonMethod < TOOLTIP_COMPARISON_SINGLE
+        or comparisonMethod > TOOLTIP_COMPARISON_BAG_OFF_HAND then
+        return
+    end
+
+    local primaryItem = CopyTooltipComparisonItem(comparisonInfo.item)
+    if not primaryItem then
+        return
+    end
+
+    local additionalItems = {}
+    local seenItems = {}
+    local primaryKey = GetTooltipComparisonItemKey(primaryItem)
+    if primaryKey then
+        seenItems[primaryKey] = true
+    end
+
+    if IsSafeValue(comparisonInfo.additionalItems)
+        and type(comparisonInfo.additionalItems) == "table" then
+        for _, item in ipairs(comparisonInfo.additionalItems) do
+            local additionalItem = CopyTooltipComparisonItem(item)
+            local itemKey = GetTooltipComparisonItemKey(additionalItem)
+            if additionalItem and (not itemKey or not seenItems[itemKey]) then
+                additionalItems[#additionalItems + 1] = additionalItem
+                if itemKey then
+                    seenItems[itemKey] = true
+                end
+                -- Retail currently returns at most the alternate equipment
+                -- slots and weapon pairings. Keep malformed data bounded.
+                if #additionalItems >= 4 then
+                    break
+                end
+            end
+        end
+    end
+
+    local equippedHeader = IsSafeString(_G.EQUIPPED) and _G.EQUIPPED or "Equipped"
+    local lines = {}
+
+    if comparisonMethod == TOOLTIP_COMPARISON_SINGLE then
+        local comparisonItems = { primaryItem }
+        for _, item in ipairs(additionalItems) do
+            comparisonItems[#comparisonItems + 1] = item
+        end
+
+        for _, equippedItem in ipairs(comparisonItems) do
+            AddTooltipComparisonItemSummary(lines, equippedItem, equippedHeader)
+            local deltaLines = GetTooltipComparisonDelta(
+                comparisonItem,
+                equippedItem,
+                nil,
+                false
+            )
+            AddTooltipComparisonDelta(lines, deltaLines, false)
+        end
+    else
+        local pairedItem = additionalItems[1]
+        local isBagPair = comparisonMethod == TOOLTIP_COMPARISON_BAG_MAIN_HAND
+            or comparisonMethod == TOOLTIP_COMPARISON_BAG_OFF_HAND
+
+        AddTooltipComparisonItemSummary(lines, primaryItem, equippedHeader)
+        if pairedItem then
+            local pairedHeader = isBagPair
+                and (IsSafeString(_G.IF_EQUIPPED_TOGETHER)
+                    and _G.IF_EQUIPPED_TOGETHER or "Equipped With")
+                or equippedHeader
+            AddTooltipComparisonItemSummary(lines, pairedItem, pairedHeader)
+        end
+
+        local deltaLines = GetTooltipComparisonDelta(
+            comparisonItem,
+            primaryItem,
+            pairedItem,
+            isBagPair
+        )
+        AddTooltipComparisonDelta(
+            lines,
+            deltaLines,
+            comparisonMethod == TOOLTIP_COMPARISON_BOTH_HANDS
+        )
+    end
+
+    return #lines > 0 and lines or nil
+end
+
 local function BuildRewardLabel(flags)
     local labels = {}
 
@@ -361,6 +822,26 @@ local function BuildRewardLabel(flags)
     end
 
     return tconcat(labels, ", ")
+end
+
+local function BuildRewardDisplay(flags, details)
+    local rewardTexts = {}
+
+    if type(details) == "table" then
+        for _, detail in ipairs(details) do
+            if type(detail) == "table"
+                and IsSafeString(detail.rowText)
+                and detail.rowText ~= "" then
+                rewardTexts[#rewardTexts + 1] = detail.rowText
+            end
+        end
+    end
+
+    if #rewardTexts > 0 then
+        return tconcat(rewardTexts, ", ")
+    end
+
+    return BuildRewardLabel(flags)
 end
 
 local function IsRewardVisible(flags)
@@ -386,9 +867,44 @@ local function BuildQuestTooltip(info)
     local lines = {
         "|cffffffff" .. info.title .. "|r",
         L["Zone"] .. ": " .. info.zoneName,
-        L["Reward"] .. ": " .. info.rewardLabel,
-        L["Time Left"] .. ": " .. info.timeLabel,
     }
+
+    local addedRewardDetails = false
+    if type(info.rewardDetails) == "table" then
+        for _, detail in ipairs(info.rewardDetails) do
+            if type(detail) == "table"
+                and IsSafeString(detail.tooltipText)
+                and detail.tooltipText ~= "" then
+                if not addedRewardDetails then
+                    local rewardHeader = IsSafeString(_G.QUEST_REWARDS)
+                        and _G.QUEST_REWARDS or L["Reward"]
+                    lines[#lines + 1] = "|cffffd100" .. rewardHeader .. "|r"
+                    addedRewardDetails = true
+                end
+                lines[#lines + 1] = (QUEST_DASH or "- ") .. detail.tooltipText
+                if type(detail.itemTooltipLines) == "table" then
+                    for _, itemLine in ipairs(detail.itemTooltipLines) do
+                        if IsSafeString(itemLine) and itemLine ~= "" then
+                            lines[#lines + 1] = "  " .. itemLine
+                        end
+                    end
+                end
+                if type(detail.itemComparisonLines) == "table" then
+                    for _, comparisonLine in ipairs(detail.itemComparisonLines) do
+                        if IsSafeString(comparisonLine) and comparisonLine ~= "" then
+                            lines[#lines + 1] = "  " .. comparisonLine
+                        end
+                    end
+                end
+            end
+        end
+    end
+
+    if not addedRewardDetails then
+        lines[#lines + 1] = L["Reward"] .. ": " .. info.rewardLabel
+    end
+
+    lines[#lines + 1] = L["Time Left"] .. ": " .. info.timeLabel
 
     if info.factionName then
         lines[#lines + 1] = L["Faction"] .. ": " .. info.factionName
@@ -613,11 +1129,11 @@ function Nx.Quest.WQList:Open()
         false
     )
     self.List = list
-    list:SetMinSize(460, 120)
+    list:SetMinSize(580, 120)
     list:ColumnAdd("", COLUMN_ICON, 16)
     list:ColumnAdd(L["Name"], COLUMN_NAME, 190)
     list:ColumnAdd(L["Zone"], COLUMN_ZONE, 105)
-    list:ColumnAdd(L["Reward"], COLUMN_REWARD, 115)
+    list:ColumnAdd(L["Reward"], COLUMN_REWARD, 190)
     list:ColumnAdd(L["Time Left"], COLUMN_TIME, 70)
     list:SetUser(self, self.OnListEvent)
     list.Frm.NxSetSize = function(_, width, height)
@@ -694,6 +1210,7 @@ function Nx.Quest.WQList:Open()
     self:RegisterEvent("UNIT_QUEST_LOG_CHANGED", "ScheduleUpdateDB")
     self:RegisterEvent("QUEST_DATA_LOAD_RESULT", "ScheduleUpdateDB")
     self:RegisterEvent("GET_ITEM_INFO_RECEIVED", "ScheduleUpdateDB")
+    self:RegisterEvent("PLAYER_EQUIPMENT_CHANGED", "ScheduleUpdateDB")
     self:RegisterEvent("QUEST_WATCH_LIST_CHANGED", "OnWatchListChanged")
 
     win.Frm:SetScript("OnShow", function()
@@ -731,27 +1248,23 @@ function Nx.Quest.WQList:ToggleWorldQuestWatch(questID)
     end
 
     local shouldTrack = not IsWorldQuestWatched(questID)
-    local canTrack = QuestUtil and QuestUtil.TrackWorldQuest
-        or C_QuestLog.AddWorldQuestWatch
-    local canUntrack = QuestUtil and QuestUtil.UntrackWorldQuest
-        or C_QuestLog.RemoveWorldQuestWatch
+    local canTrack = Nx.AddWorldQuestWatchSafe
+    local canUntrack = Nx.RemoveWorldQuestWatchSafe
     if shouldTrack and not canTrack or not shouldTrack and not canUntrack then
         return
     end
 
     -- Match Carbonite's world-map pin path: leave the tainted row-click stack
     -- before touching Blizzard's watch API, and defer again if combat begins.
+    -- Call the native watch API through Carbonite's secure boundary rather
+    -- than QuestUtil's Lua wrapper: removing the currently super-tracked WQ
+    -- synchronously calls Blizzard_QuestSuperTracking, whose map refresh would
+    -- otherwise inherit Carbonite taint and block SetPassThroughButtons.
     local function ApplyWatchChange()
         if shouldTrack then
-            if QuestUtil and QuestUtil.TrackWorldQuest then
-                QuestUtil.TrackWorldQuest(questID, QUEST_WATCH_MANUAL)
-            else
-                C_QuestLog.AddWorldQuestWatch(questID, QUEST_WATCH_MANUAL)
-            end
-        elseif QuestUtil and QuestUtil.UntrackWorldQuest then
-            QuestUtil.UntrackWorldQuest(questID)
+            Nx.AddWorldQuestWatchSafe(questID, QUEST_WATCH_MANUAL)
         else
-            C_QuestLog.RemoveWorldQuestWatch(questID)
+            Nx.RemoveWorldQuestWatchSafe(questID)
         end
 
         self:OnWatchListChanged()
@@ -828,13 +1341,14 @@ end
 
 function Nx.Quest.WQList:ClassifyRewards(questID, tagInfo)
     local flags = {}
+    local details = {}
 
     if HaveQuestRewardData then
         local rewardDataLoaded = HaveQuestRewardData(questID)
         if not IsSafeValue(rewardDataLoaded) or rewardDataLoaded ~= true then
             flags.pending = true
             self:RequestRewardData(questID)
-            return flags
+            return flags, details
         end
     end
 
@@ -843,24 +1357,48 @@ function Nx.Quest.WQList:ClassifyRewards(questID, tagInfo)
         flags.pvp = true
     end
 
+    local honor
     if GetQuestLogRewardHonor then
-        local honor = GetQuestLogRewardHonor(questID)
-        if IsSafeNumber(honor) and honor > 0 then
+        local rewardHonor = GetQuestLogRewardHonor(questID)
+        if IsSafeNumber(rewardHonor) and rewardHonor > 0 then
+            honor = rewardHonor
             flags.pvp = true
         end
     end
 
+    local artifactPower
     if GetQuestLogRewardArtifactXP then
-        local artifactPower = GetQuestLogRewardArtifactXP(questID)
-        if IsSafeNumber(artifactPower) and artifactPower > 0 then
+        local rewardArtifactPower = GetQuestLogRewardArtifactXP(questID)
+        if IsSafeNumber(rewardArtifactPower) and rewardArtifactPower > 0 then
+            artifactPower = rewardArtifactPower
             flags.power = true
         end
     end
 
+    local money
     if GetQuestLogRewardMoney then
-        local money = GetQuestLogRewardMoney(questID)
-        if IsSafeNumber(money) and money > 0 then
+        local rewardMoney = GetQuestLogRewardMoney(questID)
+        if IsSafeNumber(rewardMoney) and rewardMoney > 0 then
+            money = rewardMoney
             flags.gold = true
+        end
+    end
+
+    local experience
+    if GetQuestLogRewardXP then
+        local totalExperience, baseExperience = GetQuestLogRewardXP(questID)
+        if IsSafeNumber(baseExperience) and baseExperience > 0 then
+            experience = baseExperience
+        elseif IsSafeNumber(totalExperience) and totalExperience > 0 then
+            experience = totalExperience
+        end
+    end
+
+    local favor
+    if C_QuestInfoSystem and C_QuestInfoSystem.GetQuestLogRewardFavor then
+        local rewardFavor = C_QuestInfoSystem.GetQuestLogRewardFavor(questID)
+        if IsSafeNumber(rewardFavor) and rewardFavor > 0 then
+            favor = rewardFavor
         end
     end
 
@@ -868,10 +1406,35 @@ function Nx.Quest.WQList:ClassifyRewards(questID, tagInfo)
         local rewardCount = GetNumQuestLogRewards(questID)
         if IsSafeNumber(rewardCount) then
             for rewardIndex = 1, rewardCount do
-                local itemName, _, _, _, _, itemID =
+                local itemName, itemTexture, itemCount, _, _, itemID =
                     GetQuestLogRewardInfo(rewardIndex, questID)
 
+                local addedItem = AddNamedReward(
+                    details,
+                    itemName,
+                    itemCount,
+                    itemTexture,
+                    false
+                )
+                local itemDetail = addedItem and details[#details] or nil
+
                 if IsSafeNumber(itemID) and itemID > 0 then
+                    if itemDetail and C_TooltipInfo
+                        and type(C_TooltipInfo.GetQuestLogItem) == "function" then
+                        local itemTooltipLines, tooltipDataReady, tooltipData =
+                            GetQuestRewardItemTooltipLines(questID, rewardIndex, itemName)
+                        if tooltipDataReady then
+                            itemDetail.itemTooltipLines = itemTooltipLines
+                            itemDetail.itemComparisonLines =
+                                GetQuestRewardItemComparisonLines(tooltipData)
+                        else
+                            flags.pending = true
+                            if C_Item and C_Item.RequestLoadItemDataByID then
+                                C_Item.RequestLoadItemDataByID(itemID)
+                            end
+                        end
+                    end
+
                     local categorized = false
                     local itemPending = false
 
@@ -928,7 +1491,29 @@ function Nx.Quest.WQList:ClassifyRewards(questID, tagInfo)
             usedModernCurrencies = true
             for _, currencyReward in ipairs(currencyRewards) do
                 if type(currencyReward) == "table" then
-                    AddCurrencyReward(flags, currencyReward.currencyID)
+                    local currencyID = currencyReward.currencyID
+                    AddCurrencyReward(flags, currencyID)
+
+                    local currencyName = currencyReward.name
+                    local currencyTexture = currencyReward.texture
+                    if (not IsSafeString(currencyName) or currencyName == "")
+                        and IsSafeNumber(currencyID)
+                        and C_CurrencyInfo
+                        and C_CurrencyInfo.GetCurrencyInfo then
+                        local currencyInfo = C_CurrencyInfo.GetCurrencyInfo(currencyID)
+                        if type(currencyInfo) == "table" then
+                            currencyName = currencyInfo.name
+                            currencyTexture = currencyInfo.iconFileID
+                        end
+                    end
+
+                    AddNamedReward(
+                        details,
+                        currencyName,
+                        currencyReward.totalRewardAmount,
+                        currencyTexture,
+                        true
+                    )
                 end
             end
         end
@@ -940,9 +1525,16 @@ function Nx.Quest.WQList:ClassifyRewards(questID, tagInfo)
         local currencyCount = GetNumQuestLogRewardCurrencies(questID)
         if IsSafeNumber(currencyCount) then
             for currencyIndex = 1, currencyCount do
-                local _, _, _, currencyID =
+                local currencyName, currencyTexture, currencyAmount, currencyID =
                     GetQuestLogRewardCurrencyInfo(currencyIndex, questID)
                 AddCurrencyReward(flags, currencyID)
+                AddNamedReward(
+                    details,
+                    currencyName,
+                    currencyAmount,
+                    currencyTexture,
+                    true
+                )
             end
         end
     end
@@ -950,14 +1542,107 @@ function Nx.Quest.WQList:ClassifyRewards(questID, tagInfo)
     if C_QuestLog and C_QuestLog.GetQuestLogMajorFactionReputationRewards then
         local reputationRewards =
             C_QuestLog.GetQuestLogMajorFactionReputationRewards(questID)
-        if type(reputationRewards) == "table" and #reputationRewards > 0 then
-            flags.reputation = true
+        if type(reputationRewards) == "table" then
+            for _, reputationReward in ipairs(reputationRewards) do
+                if type(reputationReward) == "table"
+                    and IsSafeNumber(reputationReward.factionID) then
+                    local factionName
+                    if C_MajorFactions and C_MajorFactions.GetMajorFactionData then
+                        local factionData =
+                            C_MajorFactions.GetMajorFactionData(reputationReward.factionID)
+                        if type(factionData) == "table"
+                            and IsSafeString(factionData.name) then
+                            factionName = factionData.name
+                        end
+                    end
+                    factionName = factionName
+                        or GetFactionName(reputationReward.factionID)
+
+                    local reputationName = factionName
+                    if factionName and IsSafeString(_G.QUEST_REPUTATION_REWARD_TITLE) then
+                        reputationName = format(
+                            _G.QUEST_REPUTATION_REWARD_TITLE,
+                            factionName
+                        )
+                    end
+
+                    flags.reputation = true
+                    AddNamedReward(
+                        details,
+                        reputationName,
+                        reputationReward.rewardAmount,
+                        nil,
+                        true
+                    )
+                end
+            end
         end
     end
 
-    if not HasKnownReward(flags) and GetQuestLogRewardXP then
-        local experience = GetQuestLogRewardXP(questID)
-        if IsSafeNumber(experience) and experience > 0 then
+    if C_QuestInfoSystem
+        and C_QuestInfoSystem.GetQuestRewardSpells
+        and C_QuestInfoSystem.GetQuestRewardSpellInfo then
+        local spellRewards = C_QuestInfoSystem.GetQuestRewardSpells(questID)
+        if type(spellRewards) == "table" then
+            for _, spellID in ipairs(spellRewards) do
+                if IsSafeNumber(spellID) and spellID > 0 then
+                    local spellInfo =
+                        C_QuestInfoSystem.GetQuestRewardSpellInfo(questID, spellID)
+                    if type(spellInfo) == "table"
+                        and AddNamedReward(
+                            details,
+                            spellInfo.name,
+                            nil,
+                            spellInfo.texture,
+                            false
+                        ) then
+                        flags.other = true
+                    end
+                end
+            end
+        end
+    end
+
+    if money then
+        local moneyText
+        if GetMoneyString then
+            local formattedMoney = GetMoneyString(money, true)
+            if IsSafeString(formattedMoney) and formattedMoney ~= "" then
+                moneyText = formattedMoney
+            end
+        end
+        moneyText = moneyText or FormatRewardAmount(money)
+        AddRewardText(details, moneyText)
+    end
+
+    if honor then
+        AddNamedReward(details, _G.HONOR or L["PvP"], honor, nil, true)
+    end
+
+    if artifactPower then
+        AddNamedReward(
+            details,
+            _G.ARTIFACT_POWER or L["Power"],
+            artifactPower,
+            nil,
+            true
+        )
+    end
+
+    if favor then
+        flags.other = true
+        AddNamedReward(
+            details,
+            _G.HOUSING_DASHBOARD_REWARD_ESTATE_XP or L["Other"],
+            favor,
+            nil,
+            true
+        )
+    end
+
+    if experience then
+        AddNamedReward(details, _G.XP or "XP", experience, nil, true)
+        if not HasKnownReward(flags) then
             flags.other = true
         end
     end
@@ -966,7 +1651,7 @@ function Nx.Quest.WQList:ClassifyRewards(questID, tagInfo)
         flags.other = true
     end
 
-    return flags
+    return flags, details
 end
 
 function Nx.Quest.WQList:GenWQTip(questID)
@@ -1106,7 +1791,7 @@ function Nx.Quest.WQList:AddQuestToSnapshot(snapshot, taskInfo, scanMapID)
     end
 
     local tagInfo = GetQuestTagInfoCompat and GetQuestTagInfoCompat(questID)
-    local rewardFlags = self:ClassifyRewards(questID, tagInfo)
+    local rewardFlags, rewardDetails = self:ClassifyRewards(questID, tagInfo)
     local timeLabel = IsSafeNumber(timeLeftSeconds)
         and Nx.Util_GetTimeElapsedStr(max(0, timeLeftSeconds))
         or L["Unknown"]
@@ -1122,7 +1807,9 @@ function Nx.Quest.WQList:AddQuestToSnapshot(snapshot, taskInfo, scanMapID)
         zoneName = GetMapName(questMapID),
         numobjectives = numObjectives,
         rewardFlags = rewardFlags,
-        rewardLabel = BuildRewardLabel(rewardFlags),
+        rewardDetails = rewardDetails,
+        rewardTypeLabel = BuildRewardLabel(rewardFlags),
+        rewardLabel = BuildRewardDisplay(rewardFlags, rewardDetails),
         timeLeftSeconds = timeLeftSeconds,
         timeLabel = timeLabel,
         PVP = rewardFlags.pvp == true,
@@ -1358,7 +2045,7 @@ function Nx.Quest.WQList:Update()
         list:ItemAdd(info)
         list:ItemSet(COLUMN_NAME, info.title)
         list:ItemSet(COLUMN_ZONE, info.zoneName)
-        list:ItemSet(COLUMN_REWARD, info.rewardLabel)
+        list:ItemSet(COLUMN_REWARD, info.rewardTypeLabel)
         list:ItemSet(COLUMN_TIME, info.timeLabel)
         list:ItemSetButton("QuestWatchCustomTip", isWatched)
         list:ItemSetButtonTip(

--- a/Carbonite/Modules/Map/MapEngine.lua
+++ b/Carbonite/Modules/Map/MapEngine.lua
@@ -42,6 +42,19 @@ local L = LibStub("AceLocale-3.0"):GetLocale("Carbonite")
 -- Extended tooltip library for enhanced tooltips
 local ExtToolTip = LibStub('LibQTip-1.0RS')
 
+-- Carbonite replaces ToggleWorldMap, so opening or closing Blizzard's map can
+-- originate in addon code. Enter Blizzard's map lifecycle through a secure
+-- call; otherwise its OnShow/OnHide provider refresh creates tainted reusable
+-- pins before the player ever hovers them.
+local securecallfunction = _G.securecallfunction
+local function CallBlizzardMapSecurely(api, ...)
+    if securecallfunction then
+        securecallfunction(api, ...)
+    else
+        api(...)
+    end
+end
+
 -------------------------------------------------------------------------------
 -- Relocation note
 -------------------------------------------------------------------------------
@@ -322,15 +335,22 @@ end
 -- @param zone  The map ID to display
 --
 function Nx.Map:SetMapByID(zone)
-    -- Only push the id into Blizzard's WorldMapFrame when it's actually shown
-    -- AND its zoom data exists. Carbonite normally keeps WorldMapFrame hidden
-    -- and reads the hovered zone from Nx.Map.MouseIsOverMap (see
-    -- GetCurrentMapAreaID), so we must NOT call SetMapID for our own hidden
-    -- map: that taints WorldMapFrame's data providers (WorldQuestDataProvider
-    -- -> AcquirePin -> SetPassThroughButtons gets ADDON_ACTION_BLOCKED when a
-    -- world quest later refreshes). zoomLevels is nil while hidden post-12.0.5,
-    -- so this stays a no-op for the Carbonite map -- exactly what we want.
-    if not WorldMapFrame:IsShown() and WorldMapFrame.ScrollContainer.zoomLevels then
+    -- Retail C_Map queries no longer depend on WorldMapFrame's selected map.
+    -- Never drive that Blizzard frame from Carbonite: SetMapID refreshes all
+    -- of its providers synchronously in our execution context. Reused AreaPOI
+    -- pins then taint GameTooltip's secret widget dimensions, while quest pins
+    -- can reach the protected SetPassThroughButtons call.
+    if Nx.isRetail then
+        return
+    end
+
+    -- Preserve the prior hidden-frame priming behavior on Classic branches,
+    -- where legacy map selection still depends on it and secret widget values
+    -- are not exposed. The Retail return above is the strict taint boundary.
+    if WorldMapFrame
+        and not WorldMapFrame:IsShown()
+        and WorldMapFrame.ScrollContainer
+        and WorldMapFrame.ScrollContainer.zoomLevels then
         -- Translate continent IDs for non-MoP Classic clients
         if Nx.OldMapIDs then
             if zone == 12 then zone = 1414 end      -- Kalimdor
@@ -1835,7 +1855,7 @@ function Nx.Map:OnWin(typ)
     elseif typ == "SizeMax" then
         -- Maximized
         if WorldMapFrame:IsShown() then
-            HideUIPanel(WorldMapFrame)
+            CallBlizzardMapSecurely(HideUIPanel, WorldMapFrame)
         end
         tinsert(UISpecialFrames, self:GetWinName())
         self:AttachWorldMap()
@@ -3633,13 +3653,9 @@ end
 Nx.Map.WMFOnShow = true
 
 -- Hook WorldMapFrame OnShow to intercept and potentially redirect to Carbonite map
--- NOTE: the HideUIPanel redirect below writes WorldMapFrame's shown state
--- from insecure code, tainting it until /reload. Secure code reads it back
--- in ActionBarController (UpdateMicroButtons -> QuestLogMicroButton), which
--- can block OverrideActionBar:Show() on vehicle transitions in combat.
--- Unavoidable while we redirect the Blizzard map; the per-login variant of
--- this taint (SetupPipeline's old ShowUIPanel/HideUIPanel priming) has been
--- removed, so this only bites in sessions where the Blizzard map was opened.
+-- The redirect enters HideUIPanel through CallBlizzardMapSecurely so reusable
+-- MapCanvas pins and Blizzard's panel state are not written from Carbonite's
+-- execution context.
 WorldMapFrame:HookScript("OnShow", function()
     -- Fix for ElvUI constant WorldMapFrame Show and Hide
     if ElvUI then
@@ -3665,13 +3681,13 @@ WorldMapFrame:HookScript("OnShow", function()
             if DugisGuideViewer then
                 local isGuideMode, isEssentialMode, isOffMode = DugisGuideViewer.GetPluginMode()
                 if not isOffMode and GPSArrowIcon and not GPSArrowIcon:IsShown() then
-                    HideUIPanel(WorldMapFrame)
+                    CallBlizzardMapSecurely(HideUIPanel, WorldMapFrame)
                     return
                 end
             end
 
             -- Redirect to Carbonite map
-            HideUIPanel(WorldMapFrame)
+            CallBlizzardMapSecurely(HideUIPanel, WorldMapFrame)
             Nx.Map:ToggleSize()
         end
     end
@@ -3739,7 +3755,7 @@ end
 function Nx.Map:BlizzToggleWorldMap()
     if WorldMapFrame:IsShown() then
         if not InCombatLockdown() then
-            HideUIPanel(WorldMapFrame)
+            CallBlizzardMapSecurely(HideUIPanel, WorldMapFrame)
         else
             WorldMapFrame:Hide()
         end
@@ -3749,7 +3765,10 @@ function Nx.Map:BlizzToggleWorldMap()
         local map = self:GetMap(1)
         map:DetachWorldMap()
         if not InCombatLockdown() then
-            WorldMapFrame:HandleUserActionToggleSelf()
+            CallBlizzardMapSecurely(
+                WorldMapFrame.HandleUserActionToggleSelf,
+                WorldMapFrame
+            )
         end
     end
 end
@@ -10757,7 +10776,7 @@ function Nx.Map:IconOnMouseDown(button)
                                     -- trips protected SetPassThroughButtons
                                     -- in combat).
                                     Nx.SuperTrackSafe(function()
-                                        C_SuperTrack.SetSuperTrackedQuestID(0)
+                                        Nx.SetSuperTrackedQuestIDSafe(0)
                                         if Nx.Quest then Nx.Quest._addWatchSuppress = _restore end
                                     end)
                                 end)
@@ -10800,12 +10819,12 @@ function Nx.Map:IconOnMouseDown(button)
                                         if C_SuperTrack.SetSuperTrackedUserWaypoint
                                            and C_SuperTrack.IsSuperTrackingUserWaypoint
                                            and C_SuperTrack.IsSuperTrackingUserWaypoint() then
-                                            C_SuperTrack.SetSuperTrackedUserWaypoint(false)
+                                            Nx.SetSuperTrackedUserWaypointSafe(false)
                                         end
                                         if C_SuperTrack.ClearAllSuperTracked then
-                                            C_SuperTrack.ClearAllSuperTracked()
+                                            Nx.ClearAllSuperTrackedSafe()
                                         end
-                                        C_SuperTrack.SetSuperTrackedQuestID(_live)
+                                        Nx.SetSuperTrackedQuestIDSafe(_live)
                                         if Nx.Quest then Nx.Quest._addWatchSuppress = _restore end
                                     end)
                                 end)

--- a/Carbonite/Modules/TaintlessHelpers/TaintlessHelpers.lua
+++ b/Carbonite/Modules/TaintlessHelpers/TaintlessHelpers.lua
@@ -23,6 +23,7 @@ Carbonite.Modules.TaintlessHelpers = TaintlessHelpers
 -- WoW Lua 5.1: `unpack` is the global; `table.unpack` (5.2+) is nil on
 -- some 12.0-engine flavors. Resolve portably.
 local unpack = table.unpack or unpack
+local securecallfunction = _G.securecallfunction
 
 function TaintlessHelpers:GetSandbox()
     return _G.NxTaintlessFrame
@@ -32,18 +33,52 @@ function TaintlessHelpers:IsAvailable()
     return self:GetSandbox() ~= nil
 end
 
--- Combat-safe wrapper for C_SuperTrack mutations
--- (SetSuperTrackedQuestID / ClearAllSuperTracked / ...). Calling
--- these from insecure code fires SUPER_TRACKING_CHANGED
--- synchronously in OUR taint context; Blizzard's
--- QuestDataProvider listener then reaches
--- pin:SetPassThroughButtons() (MapCanvas AcquirePin →
--- CheckMouseButtonPassthrough), which is protected during combat
--- lockdown → ADDON_ACTION_BLOCKED blaming Carbonite. Surfaces
--- whenever a quest-pin map (WorldMap / FlightMap) is visible while
--- the player is in combat. Out of combat the tainted chain is
--- permitted, so run synchronously to keep click-toggle ordering;
--- in combat defer to PLAYER_REGEN_ENABLED via CombatLockdown.
+-- Run a Blizzard-owned function without carrying Carbonite's execution taint
+-- into synchronous events and callback registries fired by that function.
+-- This matters on Retail 12.x because those callbacks can acquire map pins or
+-- lay out secret UI-widget dimensions before the original API call returns.
+local function CallBlizzardSecurely(api, ...)
+    if type(api) ~= "function" then
+        return false
+    end
+
+    if securecallfunction then
+        securecallfunction(api, ...)
+    else
+        -- Classic clients without securecallfunction do not expose Retail's
+        -- secret-value map/widget path. Keep their legacy behavior intact.
+        api(...)
+    end
+    return true
+end
+
+function TaintlessHelpers:SecureAPICall(api, ...)
+    if type(api) ~= "function" then
+        return false
+    end
+
+    local args = { ... }
+    local function Invoke()
+        CallBlizzardSecurely(api, unpack(args))
+    end
+
+    if _G.InCombatLockdown and _G.InCombatLockdown() then
+        local CL = Carbonite.Modules.CombatLockdown
+        if CL then
+            CL:RunWhenSafe(Invoke)
+            return true
+        end
+    end
+
+    Invoke()
+    return true
+end
+
+-- Scheduling half of the super-track boundary. This keeps a complete logical
+-- mutation together and defers it through combat; mutation closures must call
+-- the specialized *Safe wrappers below so the Blizzard C API itself is also
+-- entered through securecallfunction. A timer or regen deferral alone still
+-- executes as Carbonite and therefore does not remove taint.
 function TaintlessHelpers:SuperTrackCall(fn)
     if type(fn) ~= "function" then return end
     if _G.InCombatLockdown and _G.InCombatLockdown() then
@@ -61,6 +96,39 @@ end
 -- without going through Carbonite.Modules.
 if _G.Nx then
     _G.Nx.SuperTrackSafe = function(fn) TaintlessHelpers:SuperTrackCall(fn) end
+
+    -- Specialized wrappers deliberately secure-call the Blizzard API itself.
+    -- Secure-calling an addon closure would not protect the nested C API call.
+    _G.Nx.SetSuperTrackedQuestIDSafe = function(questID)
+        local api = _G.C_SuperTrack and _G.C_SuperTrack.SetSuperTrackedQuestID
+        return TaintlessHelpers:SecureAPICall(api, questID)
+    end
+
+    _G.Nx.SetSuperTrackedUserWaypointSafe = function(enabled)
+        local api = _G.C_SuperTrack and _G.C_SuperTrack.SetSuperTrackedUserWaypoint
+        return TaintlessHelpers:SecureAPICall(api, enabled)
+    end
+
+    _G.Nx.ClearAllSuperTrackedSafe = function()
+        local api = _G.C_SuperTrack and _G.C_SuperTrack.ClearAllSuperTracked
+        return TaintlessHelpers:SecureAPICall(api)
+    end
+
+    _G.Nx.AddWorldQuestWatchSafe = function(questID, watchType)
+        -- Prefer Blizzard's public Lua helper so its last-tracked bookkeeping
+        -- and automatic-super-track rules stay intact. securecallfunction
+        -- keeps the whole helper (including its nested C calls) on Blizzard's
+        -- side of the boundary.
+        local api = _G.QuestUtil and _G.QuestUtil.TrackWorldQuest
+            or (_G.C_QuestLog and _G.C_QuestLog.AddWorldQuestWatch)
+        return TaintlessHelpers:SecureAPICall(api, questID, watchType)
+    end
+
+    _G.Nx.RemoveWorldQuestWatchSafe = function(questID)
+        local api = _G.QuestUtil and _G.QuestUtil.UntrackWorldQuest
+            or (_G.C_QuestLog and _G.C_QuestLog.RemoveWorldQuestWatch)
+        return TaintlessHelpers:SecureAPICall(api, questID)
+    end
 end
 
 function TaintlessHelpers:ProxyCall(fn, ...)


### PR DESCRIPTION
MoP Classic - Undercity Map #548

Detailed changes:

Groups all watched World Quests beneath one shared header and prevents duplicate quest entries.
Adds complete reward-item information to the World Quest List tooltip.
Restores category-only Reward column labels while retaining detailed reward tooltips.
Adds taint-safe equipped-item comparisons, including item levels, stat differences, both ring/trinket slots, and two-handed or dual-wield configurations.
Maps MoP Undercity’s Blizzard map ID 998 to Carbonite’s canonical city ID 90.
Correctly preserves the Exodar as a city when Blizzard reports it as the Crash Site or promotes the display map to Azuremyst Isle.
Adds legacy Undercity and Exodar tile fallbacks when Blizzard supplies no usable map art.
Gives active city hotspots priority over overlapping surrounding-zone hotspots.
Clears stale and surplus map tiles, retries temporarily unavailable artwork, and prevents random or previously displayed zone maps after transitions.
Uses one consistent map resolver for rendering, player positioning, navigation, current-zone selection, and group tracking.

