### PR TITLE
World Quest Zone and Map Icon Fix

### DIFF
--- a/Carbonite.Quests/MapIcons.lua
+++ b/Carbonite.Quests/MapIcons.lua
@@ -74,6 +74,64 @@ end
 
 local GetObjectIconTextureCoords = _G.C_Minimap and _G.C_Minimap.GetObjectIconTextureCoords
 
+-- GetQuestsOnMap also returns nearby quests whose own map differs from the
+-- requested canvas. Blizzard rejects those entries except for a genuine child
+-- map or the super-tracked quest on its parent continent.
+local function GetVisibleTaskMapID(info, viewMapID, trackedQuestID)
+    if not info or type(info.questID) ~= "number"
+        or type(info.x) ~= "number" or type(info.y) ~= "number" then
+        return nil
+    end
+
+    viewMapID = tonumber(viewMapID)
+    local taskMapID = tonumber(info.mapID or info.mapId)
+    if not taskMapID and _G.GetQuestUiMapID then
+        taskMapID = tonumber(_G.GetQuestUiMapID(info.questID))
+    end
+
+    if not viewMapID or not taskMapID or taskMapID <= 0 then
+        return nil
+    end
+    if taskMapID == viewMapID then
+        return taskMapID
+    end
+
+    local mapAPI = _G.C_Map
+    local mapTypes = _G.Enum and _G.Enum.UIMapType
+    if not mapAPI or not mapAPI.GetMapInfo or not mapTypes then
+        return nil
+    end
+
+    local viewMapInfo = mapAPI.GetMapInfo(viewMapID)
+    if not viewMapInfo then
+        return nil
+    end
+
+    local isChildMapQuest = info.childDepth
+        and viewMapInfo.mapType == mapTypes.Zone
+    local isTrackedContinentQuest = info.questID == trackedQuestID
+        and viewMapInfo.mapType == mapTypes.Continent
+    if not isChildMapQuest and not isTrackedContinentQuest then
+        return nil
+    end
+
+    local ancestorMapID = taskMapID
+    for _ = 1, 16 do
+        local ancestorInfo = mapAPI.GetMapInfo(ancestorMapID)
+        local parentMapID = ancestorInfo and tonumber(ancestorInfo.parentMapID)
+        if not parentMapID or parentMapID <= 0
+            or parentMapID == ancestorMapID then
+            return nil
+        end
+        if parentMapID == viewMapID then
+            return taskMapID
+        end
+        ancestorMapID = parentMapID
+    end
+
+    return nil
+end
+
 -------------------------------------------------------------------------------
 -- Update map icons (called by map)
 -------------------------------------------------------------------------------
@@ -721,14 +779,15 @@ function Nx.Quest:UpdateIcons (map)
 
     -- BONUS TASKS and WORLD QUESTS icons
     local taskIconIndex = 1
-    local activeWQ = {}
     if C_TaskQuest and C_TaskQuest.GetQuestsOnMap
         and viewMapID ~= 9000 and not instanceIconContext then
         local taskInfo = RefreshTaskInfoCache(viewMapID, Nx.Map.mapChange)
         if taskInfo and Nx.db.char.Map.ShowWorldQuest then
             for i = 1, #taskInfo do
                 local info = taskInfo[i]
-                local questID = taskInfo[i].questID
+                local taskMapID = GetVisibleTaskMapID(info, viewMapID, activeQID)
+                if taskMapID then
+                local questID = info.questID
                 local title, faction
                 if C_TaskQuest.GetQuestInfoByQuestID then
                     title, faction = C_TaskQuest.GetQuestInfoByQuestID(questID)
@@ -779,13 +838,27 @@ function Nx.Quest:UpdateIcons (map)
                                                (classification == Enum.QuestClassification.Legendary)
                         end
                     end
-                    if QuestUtils_ShouldDisplayExpirationWarning(questID) or (timeLeft and timeLeft > 0) or isImportantQuest then
+                    local isWorldQuest = not info.isMeta
+                    if _G.QuestUtils_IsQuestWorldQuest then
+                        isWorldQuest = _G.QuestUtils_IsQuestWorldQuest(questID)
+                    end
+                    local canShowAsWorldQuest = isWorldQuest
+                        or info.isMapIndicatorQuest or isImportantQuest
+                    if canShowAsWorldQuest
+                        and (QuestUtils_ShouldDisplayExpirationWarning(questID)
+                            or (timeLeft and timeLeft > 0) or isImportantQuest) then
                         local x, y = info.x * 100, info.y * 100
+                        -- Task coordinates are normalized to the map passed
+                        -- to GetQuestsOnMap, even for a valid child-map quest.
+                        local worldX, worldY = map:GetWorldPos(viewMapID, x, y)
                         local f = map:GetIconWQ(120)
                         f.questID = info.questID
+                        f.mapID = taskMapID
 
                         -- Use hideOutside=true to completely hide icon when outside visible area
-                        if not map:ClipFrameZ(f, x, y, 24, 24, 0, true) then
+                        if not map:ClipFrameByMapType(
+                            f, worldX, worldY, 24, 24, 0, true
+                        ) then
                             -- Icon is outside visible area, skip processing
                             f:Hide()
                         else
@@ -814,10 +887,9 @@ function Nx.Quest:UpdateIcons (map)
                             -- unconditionally re-setting it; second
                             -- click on the same WQ clears it (parity
                             -- with the bonus-objective pin behaviour).
-                            local wx, wy = map:GetWorldPos(map.MapId, x, y)
-                            map:ToggleGotoQuest(self.questID, wx, wy,
+                            map:ToggleGotoQuest(self.questID, worldX, worldY,
                                 C_TaskQuest.GetQuestInfoByQuestID(self.questID),
-                                map.MapId)
+                                self.mapID)
                             if not InCombatLockdown() and self.worldQuest then
                                 if not ChatEdit_TryInsertQuestLinkForQuestID(self.questID) then
                                     -- Capture click-time inputs and
@@ -917,8 +989,10 @@ function Nx.Quest:UpdateIcons (map)
                 else
                     if not worldquestdb[questID] and title then
                         taskIconIndex = taskIconIndex + 1
-                        local x, y = taskInfo[i].x * 100, taskInfo[i].y * 100
+                        local x, y = info.x * 100, info.y * 100
+                        local worldX, worldY = map:GetWorldPos(viewMapID, x, y)
                         local f = map:GetIcon(3)
+                        f.mapID = taskMapID
 
                         local objTxt = ""
                         for objectiveIndex = 1, taskInfo[i].numObjectives do
@@ -934,7 +1008,9 @@ function Nx.Quest:UpdateIcons (map)
                             if not taskInfo[i].inProgress then
                                 f.questID = taskInfo[i].questID
                                 f.NxTip = L["|cffffd100Daily Task:\n"] .. title:gsub("Daily Objective: ", "") .. objTxt .. "\n" .. GREEN_FONT_COLOR:GenerateHexColorMarkup() .. GRANTS_FOLLOWER_XP
-                                if not map:ClipFrameZ(f, x, y, 22, 22, 0, true) then
+                                if not map:ClipFrameByMapType(
+                                    f, worldX, worldY, 22, 22, 0, true
+                                ) then
                                     f:Hide()
                                 else
                                     local left, right, top, bottom
@@ -968,7 +1044,9 @@ function Nx.Quest:UpdateIcons (map)
                             end
                         else
                             f.NxTip = L["|cffffd100Bonus Task:\n"] .. title:gsub("Bonus Objective: ", "") .. objTxt
-                            if map:ClipFrameZ(f, x, y, 22, 22, 0, true) then
+                            if map:ClipFrameByMapType(
+                                f, worldX, worldY, 22, 22, 0, true
+                            ) then
                                 local left, right, top, bottom
                                 if GetObjectIconTextureCoords then
                                     left, right, top, bottom = GetObjectIconTextureCoords(4734)
@@ -991,6 +1069,7 @@ function Nx.Quest:UpdateIcons (map)
                     end
                 end
                 end -- if not skipBonusOrThreat
+                end -- if task belongs to the displayed map
             end
         end
     end

--- a/Carbonite/Modules/Map/MapEngine.lua
+++ b/Carbonite/Modules/Map/MapEngine.lua
@@ -5435,17 +5435,18 @@ function Nx.Map:Update (elapsed)
         end
 
         -- Hide all world quest icons immediately on map change to prevent stale icons
-        local wqFrms = self.IconWQFrms
-        for n = 1, wqFrms.Used or 0 do
-            if wqFrms[n] then
-                wqFrms[n]:Hide()
-            end
-        end
-        wqFrms.Next = 1
+        self:HideWorldQuestIcons()
 
-        -- Clear quest offer cache on map change to prevent showing wrong quest titles
-        if Nx.Quest and Nx.Quest.ClearQuestOfferCache then
-            Nx.Quest:ClearQuestOfferCache()
+        -- Drop old-map task data before the next draw so adjacent-zone and
+        -- emissary entries cannot survive the transition for one frame.
+        if Nx.Quest then
+            Nx.Quest._iconDirty = true
+            if Nx.Quest.ClearTaskInfoCache then
+                Nx.Quest:ClearTaskInfoCache()
+            end
+            if Nx.Quest.ClearQuestOfferCache then
+                Nx.Quest:ClearQuestOfferCache()
+            end
         end
 
         -- Clear POI cache on map change (POI_Cache is accessed via local reference)
@@ -5484,13 +5485,7 @@ function Nx.Map:Update (elapsed)
         POI_Cache.data = nil
         POI_Cache.time = 0
 
-        local wqFrms = self.IconWQFrms
-        for n = 1, wqFrms.Used or 0 do
-            if wqFrms[n] then
-                wqFrms[n]:Hide()
-            end
-        end
-        wqFrms.Next = 1
+        self:HideWorldQuestIcons()
 
         if self.InstanceMapRelevanceCache then
             wipe(self.InstanceMapRelevanceCache)
@@ -10395,6 +10390,36 @@ end
 
 
 ------
+-- Immediately retire every world-quest frame, including frames stamped since
+-- the last ResetIcons pass. Used alone describes the previous draw and can
+-- miss newer frames, leaving their last screen anchor visible indefinitely.
+
+function Nx.Map:HideWorldQuestIcons()
+    local frms = self.IconWQFrms
+    if not frms then
+        return
+    end
+
+    local last = max(
+        frms.Used or 0,
+        (frms.Next or 1) - 1,
+        frms.MaxUsed or 0,
+        #frms
+    )
+
+    for n = 1, last do
+        local frame = frms[n]
+        if frame then
+            frame:Hide()
+        end
+    end
+
+    frms.MaxUsed = last
+    frms.Used = 0
+    frms.Next = 1
+end
+
+------
 -- Reset icons
 
 function Nx.Map:ResetIcons()
@@ -10422,7 +10447,7 @@ function Nx.Map:ResetIcons()
     local data = self.IconWQFrms
     data.Used = data.Next - 1        -- Save last used
     -- Track the maximum icons ever used (high-water mark) to ensure stale icons get hidden
-    data.MaxUsed = max(data.MaxUsed or 0, data.Used)
+    data.MaxUsed = max(data.MaxUsed or 0, data.Used, #data)
     data.Next = 1
 end
 
@@ -10462,19 +10487,17 @@ function Nx.Map:HideExtraIcons()
     end
 
     local data = self.IconWQFrms
+    local last = max(data.Used or 0, data.MaxUsed or 0, #data)
 
-    for n = data.Next, data.Used do        -- Hide up to last used amount
-        data[n]:Hide()
-    end
-
-    -- Also hide any icons beyond Used that might be visible (fixes stale icons on window activation)
-    -- This covers edge cases where icons were shown outside the normal update cycle
-    local maxWQ = data.MaxUsed or data.Used
-    for n = data.Used + 1, maxWQ do
-        if data[n] then
-            data[n]:Hide()
+    -- Frames before Next were stamped and positioned during this draw. Hide
+    -- every other allocated frame without touching newly reactivated icons.
+    for n = data.Next, last do
+        local frame = data[n]
+        if frame then
+            frame:Hide()
         end
     end
+    data.MaxUsed = last
 end
 
 ------
@@ -10652,7 +10675,12 @@ function Nx.Map:GetIconWQ (levelAdd)
     f.NXData = nil
     f.NXData2 = nil
     f.NxQuestOffer = nil      -- Clear quest offer flag
+    f.questID = nil
+    f.mapID = nil
+    f.worldQuest = nil
+    f.numObjectives = nil
 
+    frms.MaxUsed = max(frms.MaxUsed or 0, pos)
     frms.Next = pos + 1
 
     return f


### PR DESCRIPTION
* Displays world quests only on their appropriate maps.
* Prevents Valarjar, Kirin Tor, and Highmountain emissary icons from appearing over unrelated zones.
* Correctly repositions icons when zooming or panning.
* Removes off-screen and obsolete icons during map transitions.
* Preserves valid child-zone and tracked continent markers.